### PR TITLE
ci: upgrade NodeJS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ jobs:
       script: skip
       install:
         - pip install -U poetry pre-commit bumpversion twine
-        - npm install -g semantic-release@15 @semantic-release/changelog @semantic-release/git @semantic-release/exec
+        - npm install -g npm semantic-release@15 @semantic-release/changelog @semantic-release/git @semantic-release/exec
       deploy:
         provider: script
         skip_cleanup: true


### PR DESCRIPTION
[semantic-release]: node version >=8.16 is required. Found v8.12.0.
See https://github.com/semantic-release/semantic-release/blob/master/docs/support/node-version.md for more details and solutions.
Script failed with status 1