### PR TITLE
feat: root files for other programming languages

### DIFF
--- a/docs/auto_detection.rst
+++ b/docs/auto_detection.rst
@@ -12,14 +12,18 @@ Nitpick_ tries to find the root dir of the project using some hardcoded assumpti
 
 #. Starting from the current working directory, it will search for files that are usually in the root of a project:
 
-  - ``.pre-commit-config.yaml``
+  - ``.pre-commit-config.yaml`` (pre-commit_)
   - ``pyproject.toml``
   - ``setup.py``
   - ``setup.cfg``
   - ``requirements*.txt``
   - ``Pipfile`` (Pipenv_)
+  - ``tox.ini`` (tox_)
+  - ``package.json`` (JavaScript, NodeJS)
+  - ``Cargo.*`` (Rust)
+  - ``go.mod``, ``go.sum`` (Golang)
   - ``app.py`` and ``wsgi.py`` (`Flask CLI`_)
-  - ``autoapp.py``
+  - ``autoapp.py`` (Flask_)
 
 #. If none of these root files were found, search for ``manage.py``.
    On Django_ projects, it can be in another dir inside the root dir (:issue:`21`).

--- a/docs/auto_detection.rst
+++ b/docs/auto_detection.rst
@@ -10,15 +10,16 @@ Root dir of the project
 
 Nitpick_ tries to find the root dir of the project using some hardcoded assumptions.
 
-#. Starting from the current working directory, it will search for files that are usually in the root of a Python project:
+#. Starting from the current working directory, it will search for files that are usually in the root of a project:
 
-    - ``pyproject.toml``
-    - ``setup.py``
-    - ``setup.cfg``
-    - ``requirements*.txt``
-    - ``Pipfile`` (Pipenv_)
-    - ``app.py`` and ``wsgi.py`` (`Flask CLI`_)
-    - ``autoapp.py``
+  - ``.pre-commit-config.yaml``
+  - ``pyproject.toml``
+  - ``setup.py``
+  - ``setup.cfg``
+  - ``requirements*.txt``
+  - ``Pipfile`` (Pipenv_)
+  - ``app.py`` and ``wsgi.py`` (`Flask CLI`_)
+  - ``autoapp.py``
 
 #. If none of these root files were found, search for ``manage.py``.
    On Django_ projects, it can be in another dir inside the root dir (:issue:`21`).

--- a/docs/targets.rst
+++ b/docs/targets.rst
@@ -11,6 +11,7 @@
 .. _Django: https://github.com/django/django
 .. _EditorConfig: https://editorconfig.org
 .. _flake8: https://gitlab.com/pycqa/flake8
+.. _Flask: https://github.com/pallets/flask/
 .. _Flask CLI: https://flask.palletsprojects.com/en/1.1.x/cli/
 .. _Invoke: https://github.com/pyinvoke/invoke
 .. _IPython: https://github.com/ipython/ipython

--- a/src/nitpick/constants.py
+++ b/src/nitpick/constants.py
@@ -14,15 +14,40 @@ GITHUB_BASE_URL = f"https://github.com/andreoliwa/{PROJECT_NAME}/blob/"
 READ_THE_DOCS_URL = "https://nitpick.rtfd.io/en/latest/"
 
 # Special files
+# Python
 PYPROJECT_TOML = "pyproject.toml"
+SETUP_PY = "setup.py"
 SETUP_CFG = "setup.cfg"
-ROOT_PYTHON_FILES = ("setup.py", "app.py", "wsgi.py", "autoapp.py")
+REQUIREMENTS_STAR_TXT = "requirements*.txt"
+PIPFILE_STAR = "Pipfile.*"
+ROOT_PYTHON_FILES = ("app.py", "wsgi.py", "autoapp.py")
 MANAGE_PY = "manage.py"
-PRE_COMMIT_CONFIG_YAML = ".pre-commit-config.yaml"
-EDITOR_CONFIG = ".editorconfig"
 TOX_INI = "tox.ini"
 PYLINTRC = ".pylintrc"
-ROOT_FILES = (PYPROJECT_TOML, SETUP_CFG, "requirements*.txt", "Pipfile", PRE_COMMIT_CONFIG_YAML) + ROOT_PYTHON_FILES
+# Tools
+PRE_COMMIT_CONFIG_YAML = ".pre-commit-config.yaml"
+EDITOR_CONFIG = ".editorconfig"
+# JavaScript
+PACKAGE_JSON = "package.json"
+# Rust
+CARGO_STAR = "Cargo.*"
+# Golang
+GO_MOD = "go.mod"
+GO_SUM = "go.sum"
+# All root files
+ROOT_FILES = (
+    PRE_COMMIT_CONFIG_YAML,
+    PYPROJECT_TOML,
+    SETUP_PY,
+    SETUP_CFG,
+    REQUIREMENTS_STAR_TXT,
+    PIPFILE_STAR,
+    TOX_INI,
+    PACKAGE_JSON,
+    CARGO_STAR,
+    GO_MOD,
+    GO_SUM,
+) + ROOT_PYTHON_FILES
 
 SINGLE_QUOTE = "'"
 DOUBLE_QUOTE = '"'

--- a/src/nitpick/constants.py
+++ b/src/nitpick/constants.py
@@ -17,12 +17,12 @@ READ_THE_DOCS_URL = "https://nitpick.rtfd.io/en/latest/"
 PYPROJECT_TOML = "pyproject.toml"
 SETUP_CFG = "setup.cfg"
 ROOT_PYTHON_FILES = ("setup.py", "app.py", "wsgi.py", "autoapp.py")
-ROOT_FILES = (PYPROJECT_TOML, SETUP_CFG, "requirements*.txt", "Pipfile") + ROOT_PYTHON_FILES
 MANAGE_PY = "manage.py"
 PRE_COMMIT_CONFIG_YAML = ".pre-commit-config.yaml"
 EDITOR_CONFIG = ".editorconfig"
 TOX_INI = "tox.ini"
 PYLINTRC = ".pylintrc"
+ROOT_FILES = (PYPROJECT_TOML, SETUP_CFG, "requirements*.txt", "Pipfile", PRE_COMMIT_CONFIG_YAML) + ROOT_PYTHON_FILES
 
 SINGLE_QUOTE = "'"
 DOUBLE_QUOTE = '"'

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -323,10 +323,14 @@ class ProjectMock:
             expected = list(always_iterable(str_or_lines))
         return result, actual, expected
 
-    def cli_run(self, str_or_lines: StrOrList = None, apply=False, violations=0) -> "ProjectMock":
+    def cli_run(self, str_or_lines: StrOrList = None, apply=False, violations=0, exception_class=None) -> "ProjectMock":
         """Assert the expected CLI output for the chosen command."""
         cli_args = [] if apply else ["--check"]
         result, actual, expected = self._simulate_cli("run", str_or_lines, *cli_args)
+        if exception_class:
+            assert isinstance(result.exception, exception_class)
+            return self
+
         if violations:
             expected.append(f"Violations: ❌ {violations} to change manually.")
         elif str_or_lines:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,7 @@ import pytest
 
 from nitpick.constants import PYPROJECT_TOML, SETUP_CFG
 from nitpick.core import Nitpick
+from nitpick.exceptions import QuitComplainingError
 from tests.helpers import ProjectMock
 
 
@@ -19,9 +20,13 @@ def test_singleton():
 
 def test_no_root_dir(tmp_path):
     """No root dir."""
-    ProjectMock(tmp_path, pyproject_toml=False, setup_py=False).create_symlink("hello.py").flake8().assert_single_error(
+    project = ProjectMock(tmp_path, pyproject_toml=False, setup_py=False)
+    project.create_symlink("hello.py").flake8().assert_single_error(
         "NIP101 No root dir found (is this a Python project?)"
     )
+
+    # TODO: don't abort with QuitComplainingError when root files are missing
+    project.cli_run(exception_class=QuitComplainingError)
 
 
 def test_multiple_root_dirs(tmp_path):


### PR DESCRIPTION
- [x] use .pre-commit-config.yaml to indicate the root of a project
- [x] add root files for other programming languages
  - [x] Rust: `Cargo.*`
  - [x] Golang: `go.mod`, `go.sum`
  - [x] JS: `package.json`
- [x] docs
