### PR TITLE
feat: read configuration from `.nitpick.toml` or `pyproject.toml`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,12 +9,12 @@ Fixes # .
 ## Checklist
 
 - [ ] Read the [contribution guidelines](https://nitpick.readthedocs.io/en/latest/contributing.html)
-- [ ] Run `make` and `invoke test` locally
-- [ ] Write documentation when there's new API, functionality, etc.:
-  - [ ] On `README.md`
-  - [ ] On `docs/*.rst` files
+- [ ] Run `make` locally before pushing commits
 - [ ] Add tests for:
   - [ ] API
   - [ ] CLI
   - [ ] `flake8` plugin (normal mode)
   - [ ] `flake8` plugin (offline mode)
+- [ ] Write documentation when there's new API, functionality, etc.:
+  - [ ] On `README.md`
+  - [ ] On `docs/*.rst` files

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -3,7 +3,18 @@
 Configuration
 =============
 
-:ref:`the-style-file` for your project should be configured in the ``[tool.nitpick]`` section of your ``pyproject.toml`` file.
+:ref:`the-style-file` for your project should be configured in the ``[tool.nitpick]`` section of the configuration file.
+
+Possible configuration files (in order of precedence):
+
+.. auto-generated-start-config-file
+
+1. ``.nitpick.toml``
+2. ``pyproject.toml``
+
+.. auto-generated-end-config-file
+
+The first file found will be used; the other files will be ignored.
 
 You can configure your own style like this:
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -40,3 +40,11 @@ During development, you can run ``invoke clean --venv install --dry``.
 It will display the commands that would be executed; remove ``--dry`` to actually run them.
 
 :ref:`Read this page on how to install Invoke <development>`.
+
+Executable ``.tox/lint/bin/pylint`` not found
+---------------------------------------------
+
+You might get this error while running ``make`` locally.
+
+1. Run ``invoke lint`` (or ``tox -e lint`` directly) to create this tox_ environment.
+2. Run ``make`` again.

--- a/src/nitpick/cli.py
+++ b/src/nitpick/cli.py
@@ -82,7 +82,7 @@ def run(context, check_only, verbose, files):
             nit.echo(fuss.pretty)
     except QuitComplainingError as err:
         for fuss in err.violations:
-            click.secho(fuss.message, fg="red")
+            click.echo(fuss.pretty)
         raise Exit(2) from err
 
     if Reporter.manual or Reporter.fixed:
@@ -102,12 +102,14 @@ def ls(context, files):  # pylint: disable=invalid-name
     nit = get_nitpick(context)
     try:
         violations = list(nit.project.merge_styles(nit.offline))
+        error_exit_code = 1
     except QuitComplainingError as err:
         violations = err.violations
+        error_exit_code = 2
     if violations:
         for fuss in violations:
             click.echo(fuss.pretty)
-        raise Exit(1)  # TODO: test ls with invalid style
+        raise Exit(error_exit_code)  # TODO: test ls with invalid style
 
     # TODO: test API .configured_files
     for file in nit.configured_files(*files):

--- a/src/nitpick/constants.py
+++ b/src/nitpick/constants.py
@@ -7,6 +7,7 @@ PROJECT_NAME = "nitpick"
 FLAKE8_PREFIX = "NIP"
 CACHE_DIR_NAME = ".cache"
 TOML_EXTENSION = ".toml"
+DOT_NITPICK_TOML = f".nitpick{TOML_EXTENSION}"
 NITPICK_STYLE_TOML = f"nitpick-style{TOML_EXTENSION}"
 MERGED_STYLE_TOML = f"merged-style{TOML_EXTENSION}"
 RAW_GITHUB_CONTENT_BASE_URL = f"https://raw.githubusercontent.com/andreoliwa/{PROJECT_NAME}/"
@@ -36,6 +37,7 @@ GO_MOD = "go.mod"
 GO_SUM = "go.sum"
 # All root files
 ROOT_FILES = (
+    DOT_NITPICK_TOML,
     PRE_COMMIT_CONFIG_YAML,
     PYPROJECT_TOML,
     SETUP_PY,
@@ -48,6 +50,7 @@ ROOT_FILES = (
     GO_MOD,
     GO_SUM,
 ) + ROOT_PYTHON_FILES
+CONFIG_FILES = (DOT_NITPICK_TOML, PYPROJECT_TOML)
 
 SINGLE_QUOTE = "'"
 DOUBLE_QUOTE = '"'

--- a/src/nitpick/plugins/pyproject_toml.py
+++ b/src/nitpick/plugins/pyproject_toml.py
@@ -1,14 +1,14 @@
 """Enforce config on pyproject.toml."""
 from collections import OrderedDict
 from itertools import chain
+from pathlib import Path
 from typing import Iterator, Optional, Type
 
 from tomlkit import dumps, parse
 from tomlkit.toml_document import TOMLDocument
 
 from nitpick.constants import PYPROJECT_TOML
-from nitpick.core import Nitpick
-from nitpick.formats import BaseFormat
+from nitpick.formats import BaseFormat, TOMLFormat
 from nitpick.plugins import hookimpl
 from nitpick.plugins.base import NitpickPlugin
 from nitpick.plugins.info import FileInfo
@@ -43,15 +43,16 @@ class PyProjectTomlPlugin(NitpickPlugin):
 
     def enforce_rules(self) -> Iterator[Fuss]:
         """Enforce rules for missing key/value pairs in pyproject.toml."""
-        file = Nitpick.singleton().project.pyproject_toml
-        if not file:
+        file: Path = self.info.project.root / PYPROJECT_TOML
+        toml_format = TOMLFormat(path=file)
+        if not toml_format:
             return
 
-        comparison = file.compare_with_flatten(self.expected_config)
+        comparison = toml_format.compare_with_flatten(self.expected_config)
         if not comparison.has_changes:
             return
 
-        document = parse(file.as_string) if self.apply else None
+        document = parse(toml_format.as_string) if self.apply else None
         yield from chain(
             self.report(SharedViolations.DIFFERENT_VALUES, document, comparison.diff),
             self.report(SharedViolations.MISSING_VALUES, document, comparison.missing),

--- a/src/nitpick/plugins/pyproject_toml.py
+++ b/src/nitpick/plugins/pyproject_toml.py
@@ -45,9 +45,6 @@ class PyProjectTomlPlugin(NitpickPlugin):
         """Enforce rules for missing key/value pairs in pyproject.toml."""
         file: Path = self.info.project.root / PYPROJECT_TOML
         toml_format = TOMLFormat(path=file)
-        if not toml_format:
-            return
-
         comparison = toml_format.compare_with_flatten(self.expected_config)
         if not comparison.has_changes:
             return

--- a/src/nitpick/project.py
+++ b/src/nitpick/project.py
@@ -179,12 +179,13 @@ class Project:
                 continue
 
             if not config_file:
-                logger.info(f"Reading configuration from {path}")
+                logger.info(f"Config file: reading from {path}")
                 config_file = path
             else:
-                logger.warning(f"Ignoring configuration from existing {path} (reading from {config_file} instead)")
+                logger.warning(f"Config file: ignoring existing {path}")
 
         if not config_file:
+            logger.warning("Config file: none found")
             return Configuration(None, [], "")
 
         toml_format = TOMLFormat(path=config_file)

--- a/src/nitpick/project.py
+++ b/src/nitpick/project.py
@@ -116,7 +116,6 @@ class Project:
     def __init__(self, root: PathOrStr = None) -> None:
         self._chosen_root = root
 
-        self.pyproject_toml: Optional[TOMLFormat] = None
         self.tool_nitpick_dict: JsonDict = {}
         self.style_dict: JsonDict = {}
         self.nitpick_section: JsonDict = {}
@@ -168,8 +167,8 @@ class Project:
         if not pyproject_path.exists():
             return
 
-        self.pyproject_toml = TOMLFormat(path=pyproject_path)
-        self.tool_nitpick_dict = search_dict(TOOL_NITPICK_JMEX, self.pyproject_toml.as_data, {})
+        pyproject_toml = TOMLFormat(path=pyproject_path)
+        self.tool_nitpick_dict = search_dict(TOOL_NITPICK_JMEX, pyproject_toml.as_data, {})
         pyproject_errors = ToolNitpickSectionSchema().validate(self.tool_nitpick_dict)
         if not pyproject_errors:
             return

--- a/src/nitpick/violations.py
+++ b/src/nitpick/violations.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 
 import click
 
-from nitpick.constants import FLAKE8_PREFIX, READ_THE_DOCS_URL
+from nitpick.constants import CONFIG_FILES, FLAKE8_PREFIX, READ_THE_DOCS_URL
 
 if TYPE_CHECKING:
     from nitpick.plugins.info import FileInfo
@@ -37,10 +37,8 @@ class Fuss:
     @property
     def pretty(self) -> str:
         """Message to be used on the CLI."""
-        return (
-            f"{self.filename}:{self.lineno}: {FLAKE8_PREFIX}{self.code:03}"
-            f" {self.message.rstrip()}{self.colored_suggestion}"
-        )
+        filename_plus_line = f"{self.filename}:{self.lineno}: " if self.filename.strip() else ""
+        return f"{filename_plus_line}{FLAKE8_PREFIX}{self.code:03}" f" {self.message.rstrip()}{self.colored_suggestion}"
 
     def __lt__(self, other: "Fuss") -> bool:
         """Sort Fuss instances."""
@@ -76,7 +74,7 @@ class ProjectViolations(ViolationEnum):
     NO_ROOT_DIR = (
         101,
         "No root directory found for this project!"
-        " Create a configuration file on the root (.nitpick.toml or pyproject.toml)."
+        f" Create a configuration file on the root ({', '.join(CONFIG_FILES)})."
         f" See {READ_THE_DOCS_URL}configuration.html",
     )
     NO_PYTHON_FILE = (102, "No Python file was found on the root dir and subdir of {root!r}")

--- a/src/nitpick/violations.py
+++ b/src/nitpick/violations.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 
 import click
 
-from nitpick.constants import FLAKE8_PREFIX
+from nitpick.constants import FLAKE8_PREFIX, READ_THE_DOCS_URL
 
 if TYPE_CHECKING:
     from nitpick.plugins.info import FileInfo
@@ -73,7 +73,12 @@ class StyleViolations(ViolationEnum):
 class ProjectViolations(ViolationEnum):
     """Project initialization violations."""
 
-    NO_ROOT_DIR = (101, "No root dir found (is this a Python project?)")
+    NO_ROOT_DIR = (
+        101,
+        "No root directory found for this project!"
+        " Create a configuration file on the root (.nitpick.toml or pyproject.toml)."
+        f" See {READ_THE_DOCS_URL}configuration.html",
+    )
     NO_PYTHON_FILE = (102, "No Python file was found on the root dir and subdir of {root!r}")
     MISSING_FILE = (103, " should exist{extra}")
     FILE_SHOULD_BE_DELETED = (104, " should be deleted{extra}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,13 @@
-"""Pytest fixtures."""
+"""Pytest fixtures.
+
+Imports from ``nitpick`` have to be here within the fixtures, otherwise they raise an error on tox:
+
+    $ tox -e clean,py38,report
+    (...)
+    Coverage.py warning: No data was collected. (no-data-collected)
+    .tox/py38/lib/python3.8/site-packages/pytest_cov/plugin.py:271:
+     PytestWarning: Failed to generate report: No data to report.
+"""
 import logging
 from pathlib import Path
 from textwrap import dedent
@@ -8,21 +17,10 @@ from _pytest.logging import caplog as _caplog  # noqa: F401
 from loguru import logger
 from responses import RequestsMock
 
-from nitpick import PROJECT_NAME
-
 
 @pytest.fixture()
 def project_default(tmp_path):
-    """Project with the default Nitpick style.
-
-    These imports below have to be here within the fixture, otherwise they raise an error on tox:
-
-        $ tox -e clean,py38,report
-        (...)
-        Coverage.py warning: No data was collected. (no-data-collected)
-        .tox/py38/lib/python3.8/site-packages/pytest_cov/plugin.py:271:
-         PytestWarning: Failed to generate report: No data to report.
-    """
+    """Project with the default Nitpick style."""
     from nitpick.constants import NITPICK_STYLE_TOML
     from tests.helpers import ProjectMock
 
@@ -79,6 +77,8 @@ def caplog(_caplog):  # noqa: F811
             logging.getLogger(record.name).handle(record)
 
     handler_id = logger.add(PropogateHandler(), format="{message} {extra}")
+    from nitpick import PROJECT_NAME
+
     logger.enable(PROJECT_NAME)
     yield _caplog
     logger.remove(handler_id)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -58,6 +58,7 @@ class ProjectMock:
         self._flake8_errors: List[Flake8Error] = []
         self._flake8_errors_as_string: Set[str] = set()
 
+        self.nitpick_instance: Optional[Nitpick] = None
         self.root_dir: Path = tmp_path
         self.cache_dir = self.root_dir / CACHE_DIR_NAME / PROJECT_NAME
         self._mocked_response: Optional[RequestsMock] = None
@@ -93,10 +94,10 @@ class ProjectMock:
         """
         Nitpick.singleton.cache_clear()
         os.chdir(str(self.root_dir))
-        nit = Nitpick.singleton().init(offline=offline)
+        self.nitpick_instance = Nitpick.singleton().init(offline=offline)
 
         if api:
-            self._actual_violations = set(nit.run(*partial_names, apply=apply))
+            self._actual_violations = set(self.nitpick_instance.run(*partial_names, apply=apply))
 
         if flake8:
             npc = NitpickFlake8Extension(filename=str(self.files_to_lint[0]))
@@ -115,9 +116,9 @@ class ProjectMock:
         """Test only the flake8 plugin, no API."""
         return self._simulate_run(offline=offline, api=False)
 
-    def api_check(self, *partial_names: str):
+    def api_check(self, *partial_names: str, offline=False):
         """Test only the API in check mode, no flake8 plugin."""
-        return self._simulate_run(*partial_names, api=True, flake8=False, apply=False)
+        return self._simulate_run(*partial_names, offline=offline, api=True, flake8=False, apply=False)
 
     def api_apply(self, *partial_names: str):
         """Test only the API in apply mode, no flake8 plugin."""

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -323,7 +323,9 @@ class ProjectMock:
             expected = list(always_iterable(str_or_lines))
         return result, actual, expected
 
-    def cli_run(self, str_or_lines: StrOrList = None, apply=False, violations=0, exception_class=None) -> "ProjectMock":
+    def cli_run(
+        self, str_or_lines: StrOrList = None, apply=False, violations=0, exception_class=None, exit_code=None
+    ) -> "ProjectMock":
         """Assert the expected CLI output for the chosen command."""
         cli_args = [] if apply else ["--check"]
         result, actual, expected = self._simulate_cli("run", str_or_lines, *cli_args)
@@ -339,10 +341,13 @@ class ProjectMock:
             # This is useful when checking only if the error is contained in a list of errors,
             # regardless of the violation count.
             assert actual
-            del actual[-1]
+            if actual[-1].startswith("Violations"):
+                del actual[-1]
 
         compare(actual=actual, expected=expected)
-        compare(actual=result.exit_code, expected=(1 if str_or_lines else 0))
+
+        expected_exit_code = exit_code or 1 if str_or_lines else 0
+        compare(actual=result.exit_code, expected=expected_exit_code)
         return self
 
     def cli_ls(self, str_or_lines: StrOrList):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,7 @@ import pytest
 
 from nitpick.constants import PYPROJECT_TOML, SETUP_CFG
 from nitpick.core import Nitpick
-from nitpick.exceptions import QuitComplainingError
+from nitpick.violations import ProjectViolations
 from tests.helpers import ProjectMock
 
 
@@ -20,13 +20,9 @@ def test_singleton():
 
 def test_no_root_dir(tmp_path):
     """No root dir."""
-    project = ProjectMock(tmp_path, pyproject_toml=False, setup_py=False)
-    project.create_symlink("hello.py").flake8().assert_single_error(
-        "NIP101 No root dir found (is this a Python project?)"
-    )
-
-    # TODO: don't abort with QuitComplainingError when root files are missing
-    project.cli_run(exception_class=QuitComplainingError)
+    project = ProjectMock(tmp_path, pyproject_toml=False, setup_py=False).create_symlink("hello.py")
+    project.flake8().assert_single_error(f"NIP101 {ProjectViolations.NO_ROOT_DIR.message}")
+    project.cli_run(ProjectViolations.NO_ROOT_DIR.message, exit_code=2)
 
 
 def test_multiple_root_dirs(tmp_path):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,8 +21,8 @@ def test_singleton():
 def test_no_root_dir(tmp_path):
     """No root dir."""
     project = ProjectMock(tmp_path, pyproject_toml=False, setup_py=False).create_symlink("hello.py")
-    project.flake8().assert_single_error(f"NIP101 {ProjectViolations.NO_ROOT_DIR.message}")
-    project.cli_run(ProjectViolations.NO_ROOT_DIR.message, exit_code=2)
+    error = f"NIP101 {ProjectViolations.NO_ROOT_DIR.message}"
+    project.flake8().assert_single_error(error).cli_run(error, exit_code=2).cli_ls(error, exit_code=2)
 
 
 def test_multiple_root_dirs(tmp_path):

--- a/tests/test_violations.py
+++ b/tests/test_violations.py
@@ -20,6 +20,7 @@ def test_fuss_pretty(fixed):
             Fuss(fixed, "abc.txt", 1, "message", "\tsuggestion\n\t   "),
             f"abc.txt:1: NIP001 message{SUGGESTION_BEGIN}\n\tsuggestion{SUGGESTION_END}",
         ),
+        (Fuss(fixed, "  ", 3, "no filename"), "NIP003 no filename"),
     ]
     for fuss, expected in examples:
         compare(actual=fuss.pretty, expected=dedent(expected))


### PR DESCRIPTION
Fixes #328.

## Checklist

- [x] Read the [contribution guidelines](https://nitpick.readthedocs.io/en/latest/contributing.html)
- [x] Run `make` and `invoke test` locally
- [x] Add tests for:
  - [x] API: `read_configuration()`
  - [x] CLI
  - [x] `flake8` plugin (normal mode)
  - [x] `flake8` plugin (offline mode)
- [x] Write documentation when there's new API, functionality, etc.:
  - [x] On `README.md`
  - [x] On `docs/*.rst` files
