### PR TITLE
chore: move python related pre-commit configuration to python.toml

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -311,10 +311,6 @@ Contents of `styles/pre-commit/general.toml <https://github.com/andreoliwa/nitpi
           - id: debug-statements
           - id: end-of-file-fixer
           - id: trailing-whitespace
-      - repo: https://github.com/asottile/pyupgrade
-        rev: v2.13.0
-        hooks:
-          - id: pyupgrade
     """
 
 .. _example-pre-commit-main:
@@ -351,6 +347,10 @@ Contents of `styles/pre-commit/python.toml <https://github.com/andreoliwa/nitpic
           - id: python-no-eval
           - id: python-no-log-warn
           - id: rst-backticks
+      - repo: https://github.com/asottile/pyupgrade
+        rev: v2.13.0
+        hooks:
+          - id: pyupgrade
     """
 
 .. _example-pylint:

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -308,7 +308,6 @@ Contents of `styles/pre-commit/general.toml <https://github.com/andreoliwa/nitpi
       - repo: https://github.com/pre-commit/pre-commit-hooks
         rev: v3.4.0
         hooks:
-          - id: debug-statements
           - id: end-of-file-fixer
           - id: trailing-whitespace
     """
@@ -347,6 +346,10 @@ Contents of `styles/pre-commit/python.toml <https://github.com/andreoliwa/nitpic
           - id: python-no-eval
           - id: python-no-log-warn
           - id: rst-backticks
+      - repo: https://github.com/pre-commit/pre-commit-hooks
+        rev: v3.4.0
+        hooks:
+          - id: debug-statements
       - repo: https://github.com/asottile/pyupgrade
         rev: v2.13.0
         hooks:

--- a/styles/pre-commit/general.toml
+++ b/styles/pre-commit/general.toml
@@ -6,8 +6,4 @@ yaml = """
       - id: debug-statements
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v2.13.0
-    hooks:
-      - id: pyupgrade
 """

--- a/styles/pre-commit/general.toml
+++ b/styles/pre-commit/general.toml
@@ -3,7 +3,6 @@ yaml = """
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:
-      - id: debug-statements
       - id: end-of-file-fixer
       - id: trailing-whitespace
 """

--- a/styles/pre-commit/python.toml
+++ b/styles/pre-commit/python.toml
@@ -8,4 +8,8 @@ yaml = """
       - id: python-no-eval
       - id: python-no-log-warn
       - id: rst-backticks
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.13.0
+    hooks:
+      - id: pyupgrade
 """

--- a/styles/pre-commit/python.toml
+++ b/styles/pre-commit/python.toml
@@ -8,6 +8,10 @@ yaml = """
       - id: python-no-eval
       - id: python-no-log-warn
       - id: rst-backticks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+      - id: debug-statements
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.13.0
     hooks:

--- a/tests/test_pre_commit.py
+++ b/tests/test_pre_commit.py
@@ -406,6 +406,10 @@ def test_missing_different_values(tmp_path):
               - id: python-no-eval
               - id: python-no-log-warn
               - id: rst-backticks
+          - repo: https://github.com/asottile/pyupgrade
+            rev: v2.13.0
+            hooks:
+              - id: pyupgrade
           - repo: https://github.com/openstack/bashate
             rev: 0.5.0
             hooks:

--- a/tests/test_pre_commit.py
+++ b/tests/test_pre_commit.py
@@ -406,6 +406,10 @@ def test_missing_different_values(tmp_path):
               - id: python-no-eval
               - id: python-no-log-warn
               - id: rst-backticks
+          - repo: https://github.com/pre-commit/pre-commit-hooks
+            rev: v3.4.0
+            hooks:
+              - id: debug-statements
           - repo: https://github.com/asottile/pyupgrade
             rev: v2.13.0
             hooks:


### PR DESCRIPTION
## Proposed changes

- This makes styles/pre-commit/general.toml more agnostic

## Checklist

- [x] Read the [contribution guidelines](https://nitpick.rtfd.io/en/latest/contributing.html)
- [x] Run `make` locally before pushing commits
- [ ] Add tests for:
  - [ ] API
  - [ ] CLI
  - [ ] `flake8` plugin (normal mode)
  - [ ] `flake8` plugin (offline mode)
- [ ] Write documentation when there's new API, functionality, etc.:
  - [ ] On `README.md`
  - [ ] On `docs/*.rst` files
