### PR TITLE
Feature support private gh styles

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -84,6 +84,23 @@ You can also use the raw URL of a `GitHub Gist <https://gist.github.com>`_:
     [tool.nitpick]
     style = "https://gist.githubusercontent.com/andreoliwa/f4fccf4e3e83a3228e8422c01a48be61/raw/ff3447bddfc5a8665538ddf9c250734e7a38eabb/remote-style.toml"
 
+If your style is on a private GitHub repo, you can provide the token directly on the URL.
+Or you can use an environment variable to avoid keeping secrets in plain text.
+
+.. code-block:: toml
+
+    [tool.nitpick]
+    # A literal token
+    style = "github://p5iCG5AJuDgY@some-user/a-private-repo@some-branch/nitpick-style.toml"
+
+    # Or reading the secret value from the MY_AUTH_KEY env var
+    style = "github://$MY_AUTH_KEY@some-user/a-private-repo@some-branch/nitpick-style.toml"
+
+.. note::
+
+    A literal token cannot start with a ``$``.
+    All tokens must not contain any ``@`` or ``:`` characters.
+
 Style inside Python package
 ---------------------------
 

--- a/docs/generate_rst.py
+++ b/docs/generate_rst.py
@@ -246,7 +246,7 @@ def write_examples() -> int:
                 header=header,
                 dashes="-" * len(header),
                 toml_file=base_name,
-                url=GitHubURL(PROJECT_OWNER, PROJECT_NAME, f"v{__version__}", base_name).url,
+                url=GitHubURL(PROJECT_OWNER, PROJECT_NAME, f"v{__version__}", base_name, "").url,
                 # Skip TOML with JSON inside, to avoid this error message:
                 # nitpick/docs/examples.rst:193: WARNING: Could not lex literal_block as "toml". Highlighting skipped.
                 language="" if "contains_json" in toml_content else " toml",

--- a/src/nitpick/generic.py
+++ b/src/nitpick/generic.py
@@ -15,7 +15,7 @@ from jmespath.parser import ParsedResult
 from nitpick.constants import DOUBLE_QUOTE, PROJECT_NAME, SEPARATOR_FLATTEN, SEPARATOR_QUOTED_SPLIT, SINGLE_QUOTE
 from nitpick.typedefs import JsonDict, PathOrStr
 
-URL_RE = re.compile(r"[a-z]+://\w+")
+URL_RE = re.compile(r"[a-z]+://[\$\w]\w*")
 
 
 def get_subclasses(cls):
@@ -221,6 +221,12 @@ def is_url(url: str) -> bool:
     >>> is_url("http://example.com")
     True
     >>> is_url("github://andreoliwa/nitpick/styles/black")
+    True
+    >>> is_url("github://$VARNAME@andreoliwa/nitpick/styles/black")
+    True
+    >>> is_url("github://LitErAl@andreoliwa/nitpick/styles/black")
+    True
+    >>> is_url("github://notfirst$@andreoliwa/nitpick/styles/black")
     True
     """
     return bool(URL_RE.match(url))

--- a/src/nitpick/style/core.py
+++ b/src/nitpick/style/core.py
@@ -82,7 +82,7 @@ class Style:  # pylint: disable=too-many-instance-attributes
     @staticmethod
     def get_default_style_url():
         """Return the URL of the default style for the current version."""
-        return GitHubURL(PROJECT_OWNER, PROJECT_NAME, f"v{__version__}", NITPICK_STYLE_TOML).long_protocol_url
+        return GitHubURL(PROJECT_OWNER, PROJECT_NAME, f"v{__version__}", NITPICK_STYLE_TOML, None).long_protocol_url
 
     def find_initial_styles(self, configured_styles: StrOrIterable) -> Iterator[Fuss]:
         """Find the initial style(s) and include them."""

--- a/src/nitpick/style/fetchers/__init__.py
+++ b/src/nitpick/style/fetchers/__init__.py
@@ -67,7 +67,7 @@ class StyleFetcherManager:
         """
         if is_url(url):
             parsed_url = urlparse(url)
-            return parsed_url.netloc, parsed_url.scheme
+            return parsed_url.hostname, parsed_url.scheme
         return "", "file"
 
 

--- a/src/nitpick/style/fetchers/__init__.py
+++ b/src/nitpick/style/fetchers/__init__.py
@@ -67,7 +67,7 @@ class StyleFetcherManager:
         """
         if is_url(url):
             parsed_url = urlparse(url)
-            return parsed_url.hostname, parsed_url.scheme
+            return parsed_url.hostname or "", parsed_url.scheme
         return "", "file"
 
 

--- a/src/nitpick/style/fetchers/github.py
+++ b/src/nitpick/style/fetchers/github.py
@@ -21,6 +21,7 @@ class GitHubProtocol(Enum):
 
 
 def _get_token_from_querystr(querystr) -> str:
+    """Get the value of ``token`` from querystring."""
     if not querystr:
         return ""
     query_args = parse_qs(querystr)

--- a/src/nitpick/style/fetchers/http.py
+++ b/src/nitpick/style/fetchers/http.py
@@ -43,8 +43,8 @@ class HttpFetcher(StyleFetcher):
             return ""
         return contents
 
-    def _download(self, url) -> str:
+    def _download(self, url, **kwargs) -> str:
         logger.info(f"Downloading style from {url}")
-        response = self._session.get(url)
+        response = self._session.get(url, **kwargs)
         response.raise_for_status()
         return response.text

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -496,6 +496,111 @@ def test_fetch_private_github_urls(tmp_path):
     project.flake8(offline=True).assert_no_errors()
 
 
+@pytest.mark.parametrize(
+    "style_url",
+    [
+        # Without commit reference (uses default branch)
+        "github://andreoliwa/nitpick/initial.toml",
+        "gh://andreoliwa/nitpick/initial.toml",
+        # Explicit commit reference
+        "github://andreoliwa/nitpick@develop/initial.toml",
+        "gh://andreoliwa/nitpick@develop/initial.toml",
+        # Regular GitHub URL
+        "https://github.com/andreoliwa/nitpick/blob/develop/initial.toml",
+        # Raw URL directly
+        "https://raw.githubusercontent.com/andreoliwa/nitpick/develop/initial.toml",
+    ],
+)
+def test_github_url_without_token_has_no_credentials(style_url):
+    """Check private GitHub URLs with a token in various places are parsed correctly."""
+    parsed = GitHubURL.parse_url(style_url)
+    assert parsed.credentials == ()
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        # Without commit reference (uses default branch)
+        "github://token@andreoliwa/nitpick/initial.toml",
+        "gh://token@andreoliwa/nitpick/initial.toml",
+        # Explicit commit reference
+        "github://token@andreoliwa/nitpick@develop/initial.toml",
+        "gh://token@andreoliwa/nitpick@develop/initial.toml",
+        # Regular GitHub URL
+        "https://token@github.com/andreoliwa/nitpick/blob/develop/initial.toml",
+        # Raw URL directly
+        "https://token@raw.githubusercontent.com/andreoliwa/nitpick/develop/initial.toml",
+    ],
+)
+def test_github_url_with_fixed_userinfo_token_has_correct_credential(url):
+    """Check private GitHub URLs with a token in various places are parsed correctly."""
+    parsed = GitHubURL.parse_url(url)
+    assert parsed.credentials == ("token", "")
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        # Without commit reference (uses default branch)
+        "github://$TOKEN@andreoliwa/nitpick/initial.toml",
+        "gh://$TOKEN@andreoliwa/nitpick/initial.toml",
+        # Explicit commit reference
+        "github://$TOKEN@andreoliwa/nitpick@develop/initial.toml",
+        "gh://$TOKEN@andreoliwa/nitpick@develop/initial.toml",
+        # Regular GitHub URL
+        "https://$TOKEN@github.com/andreoliwa/nitpick/blob/develop/initial.toml",
+        # Raw URL directly
+        "https://$TOKEN@raw.githubusercontent.com/andreoliwa/nitpick/develop/initial.toml",
+    ],
+)
+def test_github_url_with_variable_userinfo_token_has_correct_credential(url, monkeypatch):
+    """Check private GitHub URLs with a token in various places are parsed correctly."""
+    monkeypatch.setenv("TOKEN", "envvar-token")
+    parsed = GitHubURL.parse_url(url)
+    assert parsed.credentials == ("envvar-token", "")
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        # Without commit reference (uses default branch)
+        "github://andreoliwa/nitpick/initial.toml?token=$ENVVAR",
+        "gh://andreoliwa/nitpick/initial.toml?token=$ENVVAR",
+        # Explicit commit reference
+        "github://andreoliwa/nitpick@develop/initial.toml?token=$ENVVAR",
+        "gh://andreoliwa/nitpick@develop/initial.toml?token=$ENVVAR",
+        # Regular GitHub URL
+        "https://github.com/andreoliwa/nitpick/blob/develop/initial.toml?token=$ENVVAR",
+        # Raw URL directly
+        "https://raw.githubusercontent.com/andreoliwa/nitpick/develop/initial.toml?token=$ENVVAR",
+        # token in both userinfo and queryargs uses userinfo one
+        "github://$ENVVAR@andreoliwa/nitpick/initial.toml?token=$NOTUSED",
+    ],
+)
+def test_github_url_with_variable_query_token_has_correct_credential(url, monkeypatch):
+    """Check private GitHub URLs with a token in various places are parsed correctly."""
+    monkeypatch.setenv("ENVVAR", "envvar-token")
+    parsed = GitHubURL.parse_url(url)
+    assert parsed.credentials == ("envvar-token", "")
+
+
+def test_github_url_with_missing_envvar_has_empty_credential(monkeypatch):
+    """Environment var that doesn't exist is replaced with empty string."""
+    monkeypatch.delenv("MISSINGVAR", raising=False)
+    parsed = GitHubURL.parse_url("https://github.com/foo/bar/blob/branch/filename.toml?token=$MISSINGVAR")
+    assert parsed.credentials == ()
+
+
+@pytest.mark.xfail(reason="GithubURL currently doesnt preserve query args")
+def test_github_url_query_token_retains_other_queryparams(monkeypatch):
+    """Querystring isn't modified by the token switcharoo."""
+    parsed = GitHubURL.parse_url("https://github.com/foo/bar/blob/branch/filename.toml?leavemealone=ok")
+    assert "leavemealone=ok" in parsed.url
+    parsed = GitHubURL.parse_url("https://github.com/foo/bar/blob/branch/filename.toml?token=somevar&leavemealone=ok")
+    assert parsed.credentials == ("somevar", "")
+    assert "leavemealone=ok" in parsed.url
+
+
 @responses.activate
 def test_include_remote_style_from_local_style(tmp_path):
     """Test include of remote style when there is only a local style."""


### PR DESCRIPTION
## Proposed changes

- support remote style urls of the form `gh://api_key@owner/repo/path.ext`
- support env-var expansion of auth info like `gh://$GH_AUTH_KEY@owner/repo/path` to avoid keeping secrets in plaintext config
- fix `?token=xxx` private repo access which has been [recently removed](https://github.blog/changelog/2021-04-19-sunsetting-api-authentication-via-query-parameters-and-the-oauth-applications-api/) (at least, I couldn't manage to make it work either in nitpick or with manual testing with HTTPie/curl). The fix works by converting a `token` query arg into the same format of credential as above, which is ultimately passed through `requests.get(..., auth=(KEY))`.

## Checklist

- [x] Read the [contribution guidelines](https://nitpick.rtfd.io/en/latest/contributing.html)
- [x] Run `make` locally before pushing commits
- [x] Add tests for the relevant parts:
  - [x] API *Has some, and some doctests, but might need more - suggestions welcomed*
  - [x] CLI *Don't think it has any CLI impact?*
  - [x] `flake8` plugin (normal mode) *Not sure if applies?*
  - [x] `flake8` plugin (offline mode) *Not sure if applies?*
- [x] Write documentation when there's a new API or functionality *suggestions where to document?*
