### PR TITLE
feat: default pre-commit hook now runs "nitpick fix"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,8 +11,11 @@ repos:
   - repo: local
     hooks:
       # Run nitpick also with tox, because local repos don't seem to work well with https://pre-commit.ci/
+      # Nitpick doesn't run on pre-commit.ci because it needs HTTP requests to get the default style from GitHub
+      # pre-commit.ci intentionally does not allow network access at runtime for free tier as this is easy to abuse (miners, etc.)
+      # https://github.com/pre-commit-ci/issues/issues/47
       - id: local-nitpick
-        name: "nitpick fix (modify files directly, local hook)"
+        name: "nitpick fix (auto fixing files, local hook)"
         entry: poetry run nitpick fix
         language: system
         always_run: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,15 +1,14 @@
 # https://pre-commit.com/#creating-new-hooks
 - id: nitpick
-  name: "nitpick flake8 plugin (check files only)"
-  description: "Run as a flake8 plugin and only check configuration files (TOML/INI/JSON/etc.), according to the Nitpick style"
-  entry: flake8 --select=NIP
+  name: "nitpick fix (auto fixing files)"
+  description: "Fix configuration files (TOML/INI/JSON/etc.) directly, according to the Nitpick style"
+  entry: nitpick fix
   language: python
-  types: [python]
-  always_run: true
   stages: [commit]
 
+# This hook is kept for compatibility (or if one wants to be explicit): "nitpick" does the same as "nitpick-fix" now
 - id: nitpick-fix
-  name: "nitpick fix (modify files directly)"
+  name: "nitpick fix (auto fixing files)"
   description: "Fix configuration files (TOML/INI/JSON/etc.) directly, according to the Nitpick style"
   entry: nitpick fix
   language: python

--- a/README.rst
+++ b/README.rst
@@ -229,8 +229,10 @@ You can use it as a template to configure your own style.
 Run as a pre-commit hook
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you use `pre-commit <https://pre-commit.com/>`__ on your project, add
+If you use `pre-commit <https://pre-commit.com/>`_ on your project, add
 this to the ``.pre-commit-config.yaml`` in your repository::
+
+.. code-block:: yaml
 
     repos:
       - repo: https://github.com/andreoliwa/nitpick
@@ -238,7 +240,21 @@ this to the ``.pre-commit-config.yaml`` in your repository::
         hooks:
           - id: nitpick
 
-There are 3 available hook IDs: ``nitpick``, ``nitpick-fix``, ``nitpick-check``.
+There are 3 available hook IDs:
+
+- ``nitpick`` and ``nitpick-fix`` both run the ``nitpick fix`` command;
+- ``nitpick-check`` runs ``nitpick check``.
+
+If you want to run Nitpick as a flake8 plugin instead::
+
+.. code-block:: yaml
+
+    repos:
+      - repo: https://github.com/PyCQA/flake8
+        rev: 4.0.1
+        hooks:
+          - id: flake8
+            additional_dependencies: [nitpick]
 
 More information
 ----------------

--- a/docs/generate_rst.py
+++ b/docs/generate_rst.py
@@ -355,6 +355,7 @@ def write_config() -> int:
 
 def write_readme(file_types: Set[FileType], divider: str) -> int:
     """Write the README."""
+    # TODO: quickstart.rst has some parts of README.rst as a copy/paste/change
     rows: List[Tuple[str, ...]] = [("File type", "``nitpick check``", "``nitpick fix``")]
     for file_type in sorted(file_types):
         rows.append(file_type.row)

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -65,6 +65,22 @@ If you use pre-commit_ on your project, add this to the ``.pre-commit-config.yam
         hooks:
           - id: nitpick
 
+There are 3 available hook IDs:
+
+- ``nitpick`` and ``nitpick-fix`` both run the ``nitpick fix`` command;
+- ``nitpick-check`` runs ``nitpick check``.
+
+If you want to run Nitpick_ as a flake8_ plugin instead::
+
+.. code-block:: yaml
+
+    repos:
+      - repo: https://github.com/PyCQA/flake8
+        rev: 4.0.1
+        hooks:
+          - id: flake8
+            additional_dependencies: [nitpick]
+
 To install the ``pre-commit`` and ``commit-msg`` Git hooks:
 
 .. code-block:: shell


### PR DESCRIPTION
## Proposed changes

- `nitpick` = `nitpick fix` and it should be the default command
- keep `nitpick-fix` for compatibility
- See also:
  - #161
  - #166

## Checklist

- [x] Read the [contribution guidelines](https://nitpick.rtfd.io/en/latest/contributing.html)
- [x] Run `make` locally before pushing commits
- [x] Add tests for the relevant parts:
  - [x] API
  - [x] CLI
  - [x] `flake8` plugin (normal mode)
  - [x] `flake8` plugin (offline mode)
- [x] Write documentation when there's a new API or functionality
