### PR TITLE
style: replace commitlint by commitizen

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,9 +118,8 @@ repos:
       - id: bashate
         # https://docs.openstack.org/bashate/latest/man/bashate.html#options
         args: [-i, E006]
-  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v6.0.0
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v2.20.3
     hooks:
-      - id: commitlint
+      - id: commitizen
         stages: [commit-msg]
-        additional_dependencies: ["@commitlint/config-conventional"]

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -62,6 +62,23 @@ Contents of `styles/black.toml <https://github.com/andreoliwa/nitpick/blob/v0.29
     #<YAML goes here>
     #"""]
 
+.. _example-commitizen:
+
+commitizen_
+-----------
+
+Contents of `styles/commitizen.toml <https://github.com/andreoliwa/nitpick/blob/v0.29.0/styles/commitizen.toml>`_:
+
+.. code-block:: toml
+
+    [[".pre-commit-config.yaml".repos]]
+    yaml = """
+      - repo: https://github.com/commitizen-tools/commitizen
+        hooks:
+          - id: commitizen
+            stages: [commit-msg]
+    """
+
 .. _example-editorconfig:
 
 EditorConfig_
@@ -227,19 +244,10 @@ package.json_
 
 Contents of `styles/package-json.toml <https://github.com/andreoliwa/nitpick/blob/v0.29.0/styles/package-json.toml>`_:
 
-.. code-block::
+.. code-block:: toml
 
     ["package.json"]
     contains_keys = ["name", "version", "repository.type", "repository.url", "release.plugins"]
-
-    ["package.json".contains_json]
-    commitlint = """
-      {
-        "extends": [
-          "@commitlint/config-conventional"
-        ]
-      }
-    """
 
 .. _example-poetry:
 
@@ -267,24 +275,6 @@ Contents of `styles/pre-commit/bash.toml <https://github.com/andreoliwa/nitpick/
       - repo: https://github.com/openstack/bashate
         hooks:
           - id: bashate
-    """
-
-.. _example-commitlint:
-
-commitlint_
------------
-
-Contents of `styles/pre-commit/commitlint.toml <https://github.com/andreoliwa/nitpick/blob/v0.29.0/styles/pre-commit/commitlint.toml>`_:
-
-.. code-block:: toml
-
-    [[".pre-commit-config.yaml".repos]]
-    yaml = """
-      - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-        hooks:
-          - id: commitlint
-            stages: [commit-msg]
-            additional_dependencies: ['@commitlint/config-conventional']
     """
 
 .. _example-pre-commit-hooks:

--- a/docs/generate_rst.py
+++ b/docs/generate_rst.py
@@ -56,7 +56,7 @@ STYLE_MAPPING = SortedDict(
         "package-json.toml": "package.json_",
         "poetry.toml": "Poetry_",
         "pre-commit/bash.toml": "Bash_",
-        "pre-commit/commitlint.toml": "commitlint_",
+        "commitizen.toml": "commitizen_",
         "pre-commit/general.toml": "pre-commit_ (hooks)",
         "pre-commit/main.toml": "pre-commit_ (main)",
         "pre-commit/python.toml": "pre-commit_ (Python hooks)",

--- a/docs/targets.rst
+++ b/docs/targets.rst
@@ -7,11 +7,11 @@
 
 .. _Bash: https://www.gnu.org/software/bash/
 .. _black: https://github.com/psf/black
-.. _commitlint: https://commitlint.js.org/
+.. _commitizen: https://github.com/commitizen-tools/commitizen
 .. _Django: https://github.com/django/django
 .. _EditorConfig: https://editorconfig.org
 .. _flake8: https://github.com/PyCQA/flake8
-.. _Flask: https://github.com/pallets/flask/
+.. _Flask: https://github.com/pallets/flask
 .. _Flask CLI: https://flask.palletsprojects.com/en/1.1.x/cli/
 .. _Homebrew: https://github.com/Homebrew/brew
 .. _Invoke: https://github.com/pyinvoke/invoke

--- a/nitpick-style.toml
+++ b/nitpick-style.toml
@@ -13,7 +13,7 @@ include = [
     "styles/pre-commit/general",
     "styles/pre-commit/python",
     "styles/pre-commit/bash",
-    "styles/pre-commit/commitlint",
+    "styles/commitizen",
     "styles/black",
     "styles/flake8",
     "styles/isort",

--- a/package.json
+++ b/package.json
@@ -43,28 +43,5 @@
         }
       ]
     ]
-  },
-  "commitlint": {
-    "extends": [
-      "@commitlint/config-conventional"
-    ],
-    "rules": {
-      "scope-enum": [
-        2,
-        "always",
-        [
-          "cli",
-          "flake8",
-          "style",
-          "yaml",
-          "toml",
-          "ini",
-          "json",
-          "deps",
-          "deps-dev",
-          "release"
-        ]
-      ]
-    }
   }
 }

--- a/styles/commitizen.toml
+++ b/styles/commitizen.toml
@@ -1,0 +1,7 @@
+[[".pre-commit-config.yaml".repos]]
+yaml = """
+  - repo: https://github.com/commitizen-tools/commitizen
+    hooks:
+      - id: commitizen
+        stages: [commit-msg]
+"""

--- a/styles/package-json.toml
+++ b/styles/package-json.toml
@@ -1,11 +1,2 @@
 ["package.json"]
 contains_keys = ["name", "version", "repository.type", "repository.url", "release.plugins"]
-
-["package.json".contains_json]
-commitlint = """
-  {
-    "extends": [
-      "@commitlint/config-conventional"
-    ]
-  }
-"""

--- a/styles/pre-commit/commitlint.toml
+++ b/styles/pre-commit/commitlint.toml
@@ -1,8 +1,0 @@
-[[".pre-commit-config.yaml".repos]]
-yaml = """
-  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    hooks:
-      - id: commitlint
-        stages: [commit-msg]
-        additional_dependencies: ['@commitlint/config-conventional']
-"""

--- a/tasks.py
+++ b/tasks.py
@@ -114,23 +114,6 @@ def install(ctx, deps=True, hooks=False):
         ctx.run("pre-commit gc")
 
 
-@task(help={"deps": "Update Poetry dependencies", "hooks": "Update pre-commit hooks"})
-def update(ctx, deps=True, hooks=False):
-    """Update pre-commit hooks and Poetry dependencies."""
-    if hooks:
-        # Uncomment the line below to auto update all repos except a few filtered out with egrep
-        ctx.run(
-            "yq -r '.repos[].repo' .pre-commit-config.yaml | egrep -v -e '^local' -e commitlint"
-            " | sed -E -e 's/http/--repo http/g' | xargs pre-commit autoupdate"
-        )
-
-    if deps:
-        ctx.run("poetry update")
-
-    # Also install what was updated
-    install(ctx, deps, hooks)
-
-
 @task(
     help={
         "coverage": "Run the HTML coverage report",
@@ -268,7 +251,7 @@ def lab(ctx):
     ctx.run("poetry run python docs/ideas/lab.py")
 
 
-namespace = Collection(install, update, test, doc, ci_build, lint, clean, reactions, lab)
+namespace = Collection(install, test, doc, ci_build, lint, clean, reactions, lab)
 namespace.configure(
     {
         "run": {

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -5,10 +5,24 @@ from nitpick.constants import READ_THE_DOCS_URL
 from nitpick.violations import Fuss
 from tests.helpers import ProjectMock
 
+PACKAGE_JSON_STYLE = '''
+    ["package.json"]
+    contains_keys = ["name", "version", "repository.type", "repository.url", "release.plugins"]
+
+    ["package.json".contains_json]
+    commitlint = """
+      {
+        "extends": [
+          "@commitlint/config-conventional"
+        ]
+      }
+    """
+'''
+
 
 def test_suggest_initial_contents(tmp_path):
     """Suggest initial contents for missing JSON file."""
-    ProjectMock(tmp_path).load_styles("package-json").pyproject_toml(
+    ProjectMock(tmp_path).named_style("package-json", PACKAGE_JSON_STYLE).pyproject_toml(
         """
         [tool.nitpick]
         style = ["package-json"]
@@ -38,7 +52,7 @@ def test_suggest_initial_contents(tmp_path):
 
 def test_json_file_contains_keys(tmp_path):
     """Test if JSON file contains keys."""
-    ProjectMock(tmp_path).load_styles("package-json").pyproject_toml(
+    ProjectMock(tmp_path).named_style("package-json", PACKAGE_JSON_STYLE,).pyproject_toml(
         """
         [tool.nitpick]
         style = ["package-json"]


### PR DESCRIPTION
Fixes #268.

## Proposed changes

- Simply replace the pre-commit hook for checking messages
- Keep `bumpversion` and changelog generation for now
  - Bigger change with more effort involved: actually try to release on PyPI using GitHub Actions
- Remove the `update()` task from `tasks.py`; there is already a generic one in https://github.com/andreoliwa/conjuring/commit/3bf29d9b061439385b77ecbc47cc237274ab61e8

## Checklist

- [x] Read the [contribution guidelines](https://nitpick.rtfd.io/en/latest/contributing.html)
- [x] Run `make` locally before pushing commits
- [x] Add tests for the relevant parts:
  - [x] API
  - [x] CLI
  - [x] `flake8` plugin (normal mode)
  - [x] `flake8` plugin (offline mode)
- [x] Write documentation when there's a new API or functionality
