### PR TITLE
feat: drop support for Python 3.6

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -16,7 +16,7 @@ jobs:
         # ubuntu-latest is being moved from ubuntu-18.04 to ubuntu-20.04
         # See https://github.com/actions/virtual-environments/issues/1816
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     runs-on: ${{ matrix.os }}
     env:
       PYTHONUNBUFFERED: 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,7 @@ repos:
     rev: v2.31.0
     hooks:
       - id: pyupgrade
+        args: [--py37-plus]
   - repo: https://github.com/myint/autoflake
     rev: v1.4
     hooks:
@@ -102,10 +103,8 @@ repos:
     rev: v0.931
     hooks:
       - id: mypy
-        args: [
-            # https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-show-error-codes
-            --show-error-codes,
-          ]
+        # https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-show-error-codes
+        args: [--show-error-codes]
         # Install additional types to fix new warnings that appeared on v0.910:
         # https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
         # "using --install-types is problematic"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,18 @@
 # [0.30.0](https://github.com/andreoliwa/nitpick/compare/v0.29.0...v0.30.0) (2022-01-14)
 
-
 ### Bug Fixes
 
-* style override on Windows ([#422](https://github.com/andreoliwa/nitpick/issues/422)) ([e7d2897](https://github.com/andreoliwa/nitpick/commit/e7d2897096df3ab868c97b68d915191b488e83bf))
-* use current dir; don't climb dirs to find the project root ([#421](https://github.com/andreoliwa/nitpick/issues/421)) ([3c82e8c](https://github.com/andreoliwa/nitpick/commit/3c82e8c4d019a5b25e1c0d9db1792f72cf800305))
-
+- style override on Windows ([#422](https://github.com/andreoliwa/nitpick/issues/422)) ([e7d2897](https://github.com/andreoliwa/nitpick/commit/e7d2897096df3ab868c97b68d915191b488e83bf))
+- use current dir; don't climb dirs to find the project root ([#421](https://github.com/andreoliwa/nitpick/issues/421)) ([3c82e8c](https://github.com/andreoliwa/nitpick/commit/3c82e8c4d019a5b25e1c0d9db1792f72cf800305))
 
 ### Features
 
-* default pre-commit hook now runs "nitpick fix" ([cb4c242](https://github.com/andreoliwa/nitpick/commit/cb4c242607c6810c629dc7f5604920c1b64a070e))
-* **json:** autofix JSON files ([#429](https://github.com/andreoliwa/nitpick/issues/429)) ([4b58a03](https://github.com/andreoliwa/nitpick/commit/4b58a0380f88b01c99945817e7ff9b595ea362aa))
-* nitpick init adds a [tool.nitpick] section ([36f4065](https://github.com/andreoliwa/nitpick/commit/36f4065483b1ec4308bc28b815c82aa0abac104c))
-* **yaml:** autofix .pre-commit-config.yaml (note: style changed!) ([#434](https://github.com/andreoliwa/nitpick/issues/434)) ([352b53d](https://github.com/andreoliwa/nitpick/commit/352b53d574e49ca683666fd40de3462d1396e575))
-* **yaml:** autofix GitHub Workflow files ([#437](https://github.com/andreoliwa/nitpick/issues/437)) ([6af77c4](https://github.com/andreoliwa/nitpick/commit/6af77c4293d8f964ccd249626d47c82440e6412f))
-* **yaml:** autofix YAML files ([#431](https://github.com/andreoliwa/nitpick/issues/431)) ([d8cc4b1](https://github.com/andreoliwa/nitpick/commit/d8cc4b1e80366d475c08316c54dc35393b4430dd))
+- default pre-commit hook now runs "nitpick fix" ([cb4c242](https://github.com/andreoliwa/nitpick/commit/cb4c242607c6810c629dc7f5604920c1b64a070e))
+- **json:** autofix JSON files ([#429](https://github.com/andreoliwa/nitpick/issues/429)) ([4b58a03](https://github.com/andreoliwa/nitpick/commit/4b58a0380f88b01c99945817e7ff9b595ea362aa))
+- nitpick init adds a [tool.nitpick] section ([36f4065](https://github.com/andreoliwa/nitpick/commit/36f4065483b1ec4308bc28b815c82aa0abac104c))
+- **yaml:** autofix .pre-commit-config.yaml (note: style changed!) ([#434](https://github.com/andreoliwa/nitpick/issues/434)) ([352b53d](https://github.com/andreoliwa/nitpick/commit/352b53d574e49ca683666fd40de3462d1396e575))
+- **yaml:** autofix GitHub Workflow files ([#437](https://github.com/andreoliwa/nitpick/issues/437)) ([6af77c4](https://github.com/andreoliwa/nitpick/commit/6af77c4293d8f964ccd249626d47c82440e6412f))
+- **yaml:** autofix YAML files ([#431](https://github.com/andreoliwa/nitpick/issues/431)) ([d8cc4b1](https://github.com/andreoliwa/nitpick/commit/d8cc4b1e80366d475c08316c54dc35393b4430dd))
 
 # [0.29.0](https://github.com/andreoliwa/nitpick/compare/v0.28.0...v0.29.0) (2021-11-08)
 

--- a/ci-prepare-cmd.sh
+++ b/ci-prepare-cmd.sh
@@ -4,13 +4,16 @@ set -e
 
 VERSION=$1
 bumpversion --allow-dirty --no-commit --no-tag --new-version $VERSION patch
-cat pyproject.toml
-cat /home/runner/work/nitpick/nitpick/pyproject.toml
+
+# Clean up the files touched by bumpversion
 pre-commit run --all-files end-of-file-fixer
 pre-commit run --all-files trailing-whitespace
+pre-commit run --all-files prettier
+
 rm -rf dist/
 poetry build
 
 # Hide the password
 set +x
+# TODO: ci: use poetry publish instead of twine
 twine upload --verbose --disable-progress-bar --skip-existing --password $TWINE_TEST_PASSWORD -r testpypi dist/*

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -440,6 +440,7 @@ Contents of `resources/python/hooks.toml <https://github.com/andreoliwa/nitpick/
 
     [[".pre-commit-config.yaml".repos.hooks]]
     id = "pyupgrade"
+    args = ["--py37-plus"]
 
 .. _example-ipython:
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -213,18 +213,6 @@ Contents of `resources/python/310.toml <https://github.com/andreoliwa/nitpick/bl
     ["pyproject.toml".tool.poetry.dependencies]
     python = "^3.10"
 
-.. _example-python-3-6:
-
-Python 3.6
-----------
-
-Contents of `resources/python/36.toml <https://github.com/andreoliwa/nitpick/blob/v0.30.0/resources/python/36.toml>`_:
-
-.. code-block:: toml
-
-    ["pyproject.toml".tool.poetry.dependencies]
-    python = "^3.6.1"
-
 .. _example-python-3-7:
 
 Python 3.7
@@ -390,7 +378,7 @@ Contents of `resources/python/github-workflow.toml <https://github.com/andreoliw
 
     [".github/workflows/python.yaml".jobs.build.strategy.matrix]
     os = ["ubuntu-latest", "windows-latest", "macos-latest"]
-    python-version = ["3.6", "3.7", "3.8", "3.9", "3.10"]
+    python-version = ["3.7", "3.8", "3.9", "3.10"]
 
     [".github/workflows/python.yaml".jobs.build]
     name = "${{ matrix.python-version }} ${{ matrix.os }}"
@@ -683,8 +671,7 @@ Contents of `resources/python/stable.toml <https://github.com/andreoliwa/nitpick
 
     [".readthedocs.yml".python]
     # ReadTheDocs still didn't upgrade to Python 3.9:
-    # Problem in your project's configuration. Invalid "python.version":
-    # expected one of (2, 2.7, 3, 3.5, 3.6, 3.7, 3.8, pypy3.5), got 3.9
+    # Problem in your project's configuration. Invalid "python.version"
     version = "3.8"
 
 .. _example-tox:

--- a/docs/generate_rst.py
+++ b/docs/generate_rst.py
@@ -20,15 +20,7 @@ from slugify import slugify
 from sortedcontainers import SortedDict
 
 from nitpick import PROJECT_NAME, __version__
-from nitpick.constants import (
-    CONFIG_FILES,
-    DOT,
-    EDITOR_CONFIG,
-    PROJECT_OWNER,
-    PYLINTRC,
-    READ_THE_DOCS_URL,
-    SETUP_CFG,
-)
+from nitpick.constants import CONFIG_FILES, DOT, EDITOR_CONFIG, PROJECT_OWNER, PYLINTRC, READ_THE_DOCS_URL, SETUP_CFG
 from nitpick.core import Nitpick
 from nitpick.style.fetchers.github import GitHubURL
 
@@ -60,7 +52,6 @@ STYLE_MAPPING = SortedDict(
         "any/commitlint.toml": "commitlint_",
         "python/hooks.toml": "pre-commit_ hooks for Python",
         "python/pylint.toml": "Pylint_",
-        "python/36.toml": "Python 3.6",
         "python/37.toml": "Python 3.7",
         "python/38.toml": "Python 3.8",
         "python/39.toml": "Python 3.9",

--- a/docs/ideas/yaml/contains.toml
+++ b/docs/ideas/yaml/contains.toml
@@ -3,7 +3,7 @@
 [[".github/workflows/python.yaml".contains]]
 __jmespath = "jobs.build.strategy.matrix"
 os = ["ubuntu-latest", "macos-latest", "windows-latest"]
-"python-version" = ["3.6", "3.7", "3.8", "3.9", "3.10"]
+"python-version" = ["3.7", "3.8", "3.9", "3.10"]
 
 # 3. Same as item 4 on "jmespath-on-section.toml", but with a different syntax.
 [[".github/workflows/python.yaml".contains]]
@@ -56,7 +56,7 @@ __yaml = "- uses: actions/checkout@v2"
 [[".github/workflows/python.yaml".contains_sorted]]
 __jmespath = "jobs.build.strategy.matrix"
 os = ["ubuntu-latest", "macos-latest", "windows-latest"]
-"python-version" = ["3.6", "3.7", "3.8", "3.9", "3.10"]
+"python-version" = ["3.7", "3.8", "3.9", "3.10"]
 
 [[".github/workflows/python.yaml".contains_sorted]]
 __jmespath = "jobs.build"

--- a/docs/ideas/yaml/merge_lists/merged_style.toml
+++ b/docs/ideas/yaml/merge_lists/merged_style.toml
@@ -1,4 +1,4 @@
 # This should be the result of a parent style including all the styles in this directory
 [".github/workflows/python.yaml".jobs.build.strategy.matrix]
 os = ["ubuntu-latest", "macos-latest", "windows-latest"]
-"python-version" = ["3.6", "3.7", "3.8", "3.9", "3.10"]
+"python-version" = ["3.7", "3.8", "3.9", "3.10"]

--- a/docs/ideas/yaml/merge_lists/py36.toml
+++ b/docs/ideas/yaml/merge_lists/py36.toml
@@ -1,2 +1,0 @@
-[".github/workflows/python.yaml".jobs.build.strategy.matrix]
-"python-version" = ["3.6"]

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -31,7 +31,7 @@ But they might still be present in the `entry_points.txt plugin metadata <https:
 .. code-block::
 
     $ rg nitpick.plugins.setup ~/Library/Caches/pypoetry/
-    /Users/john.doe/Library/Caches/pypoetry/virtualenvs/nitpick-UU_pZ5zs-py3.6/lib/python3.6/site-packages/nitpick-0.24.1.dist-info/entry_points.txt
+    /Users/john.doe/Library/Caches/pypoetry/virtualenvs/nitpick-UU_pZ5zs-py3.7/lib/python3.7/site-packages/nitpick-0.24.1.dist-info/entry_points.txt
     11:setup_cfg=nitpick.plugins.setup_cfg
 
 Remove and recreate the virtualenv; this should fix it.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,15 +1,4 @@
 [[package]]
-name = "aiocontextvars"
-version = "0.2.2"
-description = "Asyncio support for PEP-567 contextvars backport."
-category = "main"
-optional = false
-python-versions = ">=3.5"
-
-[package.dependencies]
-contextvars = {version = "2.4", markers = "python_version < \"3.7\""}
-
-[[package]]
 name = "alabaster"
 version = "0.7.12"
 description = "A configurable sidebar-enabled Sphinx theme"
@@ -27,11 +16,11 @@ python-versions = "*"
 
 [[package]]
 name = "astroid"
-version = "2.9.0"
+version = "2.9.3"
 description = "An abstract syntax tree for Python with inference support."
 category = "main"
 optional = true
-python-versions = "~=3.6"
+python-versions = ">=3.6.2"
 
 [package.dependencies]
 lazy-object-proxy = ">=1.4.0"
@@ -169,17 +158,6 @@ importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 testing = ["sphinx", "flake8", "pytest", "pytest-cov", "pytest-virtualenv", "pytest-xdist"]
 
 [[package]]
-name = "contextvars"
-version = "2.4"
-description = "PEP 567 Backport"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-immutables = ">=0.9"
-
-[[package]]
 name = "coverage"
 version = "6.2"
 description = "Code coverage measurement for Python"
@@ -192,14 +170,6 @@ tomli = {version = "*", optional = true, markers = "extra == \"toml\""}
 
 [package.extras]
 toml = ["tomli"]
-
-[[package]]
-name = "dataclasses"
-version = "0.8"
-description = "A backport of the dataclasses module for Python 3.6"
-category = "main"
-optional = false
-python-versions = ">=3.6, <3.7"
 
 [[package]]
 name = "decorator"
@@ -299,7 +269,7 @@ pygments = ">=2.2.0"
 
 [[package]]
 name = "identify"
-version = "2.4.3"
+version = "2.4.4"
 description = "File identification library for Python"
 category = "main"
 optional = false
@@ -323,20 +293,6 @@ description = "Getting image size from png/jpeg/jpeg2000/gif file"
 category = "main"
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[[package]]
-name = "immutables"
-version = "0.16"
-description = "Immutable Collections"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-typing-extensions = {version = ">=3.7.4.3", markers = "python_version < \"3.8\""}
-
-[package.extras]
-test = ["flake8 (>=3.8.4,<3.9.0)", "pycodestyle (>=2.6.0,<2.7.0)", "mypy (>=0.910)", "pytest (>=6.2.4,<6.3.0)"]
 
 [[package]]
 name = "importlib-metadata"
@@ -379,65 +335,6 @@ python-versions = "*"
 
 [[package]]
 name = "ipdb"
-version = "0.13.4"
-description = "IPython-enabled pdb"
-category = "dev"
-optional = false
-python-versions = ">=2.7"
-
-[package.dependencies]
-ipython = {version = ">=5.1.0", markers = "python_version >= \"3.4\""}
-
-[[package]]
-name = "ipdb"
-version = "0.13.5"
-description = "IPython-enabled pdb"
-category = "dev"
-optional = false
-python-versions = ">=2.7"
-
-[package.dependencies]
-ipython = {version = ">=7.10.0,<7.17.0", markers = "python_version == \"3.6\""}
-
-[[package]]
-name = "ipdb"
-version = "0.13.6"
-description = "IPython-enabled pdb"
-category = "dev"
-optional = false
-python-versions = ">=2.7"
-
-[package.dependencies]
-ipython = {version = ">=7.10.0,<7.17.0", markers = "python_version == \"3.6\""}
-toml = {version = ">=0.10.2", markers = "python_version == \"3.6\" or python_version > \"3.6\""}
-
-[[package]]
-name = "ipdb"
-version = "0.13.7"
-description = "IPython-enabled pdb"
-category = "dev"
-optional = false
-python-versions = ">=2.7"
-
-[package.dependencies]
-ipython = {version = ">=7.10.0,<7.17.0", markers = "python_version == \"3.6\""}
-toml = {version = ">=0.10.2", markers = "python_version == \"3.6\" or python_version > \"3.6\""}
-
-[[package]]
-name = "ipdb"
-version = "0.13.8"
-description = "IPython-enabled pdb"
-category = "dev"
-optional = false
-python-versions = ">=2.7"
-
-[package.dependencies]
-decorator = {version = "*", markers = "python_version == \"3.6\" or python_version > \"3.6\""}
-ipython = {version = ">=7.10.0,<7.17.0", markers = "python_version == \"3.6\""}
-toml = {version = ">=0.10.2", markers = "python_version == \"3.6\" or python_version > \"3.6\""}
-
-[[package]]
-name = "ipdb"
 version = "0.13.9"
 description = "IPython-enabled pdb"
 category = "dev"
@@ -445,32 +342,33 @@ optional = false
 python-versions = ">=2.7"
 
 [package.dependencies]
-decorator = {version = "*", markers = "python_version == \"3.6\" or python_version > \"3.6\""}
-ipython = {version = ">=7.10.0,<7.17.0", markers = "python_version == \"3.6\""}
-toml = {version = ">=0.10.2", markers = "python_version == \"3.6\" or python_version > \"3.6\""}
+decorator = {version = "*", markers = "python_version > \"3.6\""}
+ipython = {version = ">=7.17.0", markers = "python_version > \"3.6\""}
+toml = {version = ">=0.10.2", markers = "python_version > \"3.6\""}
 
 [[package]]
 name = "ipython"
-version = "7.16.2"
+version = "7.31.0"
 description = "IPython: Productive Interactive Computing"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 appnope = {version = "*", markers = "sys_platform == \"darwin\""}
 backcall = "*"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 decorator = "*"
-jedi = ">=0.10,<=0.17.2"
-pexpect = {version = "*", markers = "sys_platform != \"win32\""}
+jedi = ">=0.16"
+matplotlib-inline = "*"
+pexpect = {version = ">4.3", markers = "sys_platform != \"win32\""}
 pickleshare = "*"
 prompt-toolkit = ">=2.0.0,<3.0.0 || >3.0.0,<3.0.1 || >3.0.1,<3.1.0"
 pygments = "*"
 traitlets = ">=4.2"
 
 [package.extras]
-all = ["Sphinx (>=1.3)", "ipykernel", "ipyparallel", "ipywidgets", "nbconvert", "nbformat", "nose (>=0.10.1)", "notebook", "numpy (>=1.14)", "pygments", "qtconsole", "requests", "testpath"]
+all = ["Sphinx (>=1.3)", "ipykernel", "ipyparallel", "ipywidgets", "nbconvert", "nbformat", "nose (>=0.10.1)", "notebook", "numpy (>=1.17)", "pygments", "qtconsole", "requests", "testpath"]
 doc = ["Sphinx (>=1.3)"]
 kernel = ["ipykernel"]
 nbconvert = ["nbconvert"]
@@ -478,15 +376,7 @@ nbformat = ["nbformat"]
 notebook = ["notebook", "ipywidgets"]
 parallel = ["ipyparallel"]
 qtconsole = ["qtconsole"]
-test = ["nose (>=0.10.1)", "requests", "testpath", "pygments", "nbformat", "ipykernel", "numpy (>=1.14)"]
-
-[[package]]
-name = "ipython-genutils"
-version = "0.2.0"
-description = "Vestigial utilities from IPython"
-category = "dev"
-optional = false
-python-versions = "*"
+test = ["nose (>=0.10.1)", "requests", "testpath", "pygments", "nbformat", "ipykernel", "numpy (>=1.17)"]
 
 [[package]]
 name = "isort"
@@ -541,16 +431,18 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "jsonschema"
-version = "4.0.0"
+version = "4.4.0"
 description = "An implementation of JSON Schema validation for Python"
 category = "main"
 optional = true
-python-versions = "*"
+python-versions = ">=3.7"
 
 [package.dependencies]
 attrs = ">=17.4.0"
 importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+importlib-resources = {version = ">=1.4.0", markers = "python_version < \"3.9\""}
 pyrsistent = ">=0.14.0,<0.17.0 || >0.17.0,<0.17.1 || >0.17.1,<0.17.2 || >0.17.2"
+typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
 format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3987", "uri-template", "webcolors (>=1.11)"]
@@ -573,7 +465,6 @@ optional = false
 python-versions = ">=3.5"
 
 [package.dependencies]
-aiocontextvars = {version = ">=0.2.0", markers = "python_version < \"3.7\""}
 colorama = {version = ">=0.3.4", markers = "sys_platform == \"win32\""}
 win32-setctime = {version = ">=1.0.0", markers = "sys_platform == \"win32\""}
 
@@ -612,6 +503,17 @@ python-versions = ">=3.5"
 
 [package.dependencies]
 marshmallow = ">=3.0.0b10"
+
+[[package]]
+name = "matplotlib-inline"
+version = "0.1.3"
+description = "Inline Matplotlib backend for Jupyter"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+traitlets = "*"
 
 [[package]]
 name = "mccabe"
@@ -672,11 +574,11 @@ python-versions = "*"
 
 [[package]]
 name = "platformdirs"
-version = "2.4.0"
+version = "2.4.1"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "main"
 optional = true
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.extras]
 docs = ["Sphinx (>=4)", "furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)"]
@@ -699,11 +601,11 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.19"
+version = "3.0.24"
 description = "Library for building powerful interactive command lines in Python"
 category = "dev"
 optional = false
-python-versions = ">=3.6.1"
+python-versions = ">=3.6.2"
 
 [package.dependencies]
 wcwidth = "*"
@@ -750,11 +652,11 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "pylint"
-version = "2.12.0"
+version = "2.12.2"
 description = "python code static checker"
 category = "main"
 optional = true
-python-versions = "~=3.6"
+python-versions = ">=3.6.2"
 
 [package.dependencies]
 astroid = ">=2.9.0,<2.10"
@@ -834,11 +736,11 @@ pytest = ">=2.7.0"
 
 [[package]]
 name = "pytest-socket"
-version = "0.4.1"
+version = "0.5.0"
 description = "Pytest Plugin to disable socket calls during tests"
 category = "main"
 optional = true
-python-versions = ">=3.6,<4.0"
+python-versions = ">=3.7,<4.0"
 
 [package.dependencies]
 pytest = ">=3.6.3"
@@ -1148,11 +1050,11 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "tomli"
-version = "1.2.3"
+version = "2.0.0"
 description = "A lil' TOML parser"
 category = "main"
 optional = true
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [[package]]
 name = "tomlkit"
@@ -1164,19 +1066,14 @@ python-versions = ">=3.6,<4.0"
 
 [[package]]
 name = "traitlets"
-version = "4.3.3"
-description = "Traitlets Python config system"
+version = "5.1.1"
+description = "Traitlets Python configuration system"
 category = "dev"
 optional = false
-python-versions = "*"
-
-[package.dependencies]
-decorator = "*"
-ipython-genutils = "*"
-six = "*"
+python-versions = ">=3.7"
 
 [package.extras]
-test = ["pytest", "mock"]
+test = ["pytest"]
 
 [[package]]
 name = "typed-ast"
@@ -1247,15 +1144,15 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [[package]]
 name = "zipp"
-version = "3.6.0"
+version = "3.7.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [extras]
 doc = ["sphinx", "sphinx_rtd_theme", "sphobjinv"]
@@ -1264,14 +1161,10 @@ test = ["pytest", "pytest-cov", "testfixtures", "responses", "freezegun", "pytes
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.6.1"
-content-hash = "fde3e51d21d24c97eaff4f472c5d6c487bcf4d356c59ff3c0db44fe06d11378f"
+python-versions = "^3.7"
+content-hash = "445392a8189a3924efe2b370fcb22010d02dfb9808a4a0875a33a9e9aae1faba"
 
 [metadata.files]
-aiocontextvars = [
-    {file = "aiocontextvars-0.2.2-py2.py3-none-any.whl", hash = "sha256:885daf8261818767d8f7cbd79f9d4482d118f024b6586ef6e67980236a27bfa3"},
-    {file = "aiocontextvars-0.2.2.tar.gz", hash = "sha256:f027372dc48641f683c559f247bd84962becaacdc9ba711d583c3871fb5652aa"},
-]
 alabaster = [
     {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
     {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
@@ -1281,8 +1174,8 @@ appnope = [
     {file = "appnope-0.1.2.tar.gz", hash = "sha256:dd83cd4b5b460958838f6eb3000c660b1f9caf2a5b1de4264e941512f603258a"},
 ]
 astroid = [
-    {file = "astroid-2.9.0-py3-none-any.whl", hash = "sha256:776ca0b748b4ad69c00bfe0fff38fa2d21c338e12c84aa9715ee0d473c422778"},
-    {file = "astroid-2.9.0.tar.gz", hash = "sha256:5939cf55de24b92bda00345d4d0659d01b3c7dafb5055165c330bc7c568ba273"},
+    {file = "astroid-2.9.3-py3-none-any.whl", hash = "sha256:506daabe5edffb7e696ad82483ad0228245a9742ed7d2d8c9cdb31537decf9f6"},
+    {file = "astroid-2.9.3.tar.gz", hash = "sha256:1efdf4e867d4d8ba4a9f6cf9ce07cd182c4c41de77f23814feb27ca93ca9d877"},
 ]
 asttokens = [
     {file = "asttokens-2.0.5-py2.py3-none-any.whl", hash = "sha256:0844691e88552595a6f4a4281a9f7f79b8dd45ca4ccea82e5e05b4bbdb76705c"},
@@ -1333,9 +1226,6 @@ configupdater = [
     {file = "ConfigUpdater-3.0.1-py2.py3-none-any.whl", hash = "sha256:579764c0798095d5e0e4cf5384c63cece6282a5859c19542455ad23de7a4ab9e"},
     {file = "ConfigUpdater-3.0.1.tar.gz", hash = "sha256:372a6a6ef598a118ec17927bec9486a7d36f44ccd3e641e879e0bf998b70924e"},
 ]
-contextvars = [
-    {file = "contextvars-2.4.tar.gz", hash = "sha256:f38c908aaa59c14335eeea12abea5f443646216c4e29380d7bf34d2018e2c39e"},
-]
 coverage = [
     {file = "coverage-6.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6dbc1536e105adda7a6312c778f15aaabe583b0e9a0b0a324990334fd458c94b"},
     {file = "coverage-6.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:174cf9b4bef0db2e8244f82059a5a72bd47e1d40e71c68ab055425172b16b7d0"},
@@ -1385,10 +1275,6 @@ coverage = [
     {file = "coverage-6.2-pp36.pp37.pp38-none-any.whl", hash = "sha256:5829192582c0ec8ca4a2532407bc14c2f338d9878a10442f5d03804a95fac9de"},
     {file = "coverage-6.2.tar.gz", hash = "sha256:e2cad8093172b7d1595b4ad66f24270808658e11acf43a8f95b41276162eb5b8"},
 ]
-dataclasses = [
-    {file = "dataclasses-0.8-py3-none-any.whl", hash = "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf"},
-    {file = "dataclasses-0.8.tar.gz", hash = "sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97"},
-]
 decorator = [
     {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
     {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
@@ -1425,8 +1311,8 @@ icecream = [
     {file = "icecream-2.1.1.tar.gz", hash = "sha256:47e00e3f4e8477996e7dc420b6fa8ba53f8ced17de65320fedb5b15997b76589"},
 ]
 identify = [
-    {file = "identify-2.4.3-py2.py3-none-any.whl", hash = "sha256:ac9c919c8ac5b90d03f8e1bce6dedcbd8a3b2a59c46737c04ed852e2d307af29"},
-    {file = "identify-2.4.3.tar.gz", hash = "sha256:8d80d877441073e7222ff272da45ca5ca1d901412790544b446e7d363ad5e9f0"},
+    {file = "identify-2.4.4-py2.py3-none-any.whl", hash = "sha256:aa68609c7454dbcaae60a01ff6b8df1de9b39fe6e50b1f6107ec81dcda624aa6"},
+    {file = "identify-2.4.4.tar.gz", hash = "sha256:6b4b5031f69c48bf93a646b90de9b381c6b5f560df4cbe0ed3cf7650ae741e4d"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
@@ -1435,35 +1321,6 @@ idna = [
 imagesize = [
     {file = "imagesize-1.3.0-py2.py3-none-any.whl", hash = "sha256:1db2f82529e53c3e929e8926a1fa9235aa82d0bd0c580359c67ec31b2fddaa8c"},
     {file = "imagesize-1.3.0.tar.gz", hash = "sha256:cd1750d452385ca327479d45b64d9c7729ecf0b3969a58148298c77092261f9d"},
-]
-immutables = [
-    {file = "immutables-0.16-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:acbfa79d44228d96296279068441f980dc63dbed52522d9227ff9f4d96c6627e"},
-    {file = "immutables-0.16-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c9ed003eacb92e630ef200e31f47236c2139b39476894f7963b32bd39bafa3"},
-    {file = "immutables-0.16-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0a396314b9024fa55bf83a27813fd76cf9f27dce51f53b0f19b51de035146251"},
-    {file = "immutables-0.16-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:4a2a71678348fb95b13ca108d447f559a754c41b47bd1e7e4fb23974e735682d"},
-    {file = "immutables-0.16-cp36-cp36m-win32.whl", hash = "sha256:064001638ab5d36f6aa05b6101446f4a5793fb71e522bc81b8fc65a1894266ff"},
-    {file = "immutables-0.16-cp36-cp36m-win_amd64.whl", hash = "sha256:1de393f1b188740ca7b38f946f2bbc7edf3910d2048f03bbb8d01f17a038d67c"},
-    {file = "immutables-0.16-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fcf678a3074613119385a02a07c469ec5130559f5ea843c85a0840c80b5b71c6"},
-    {file = "immutables-0.16-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a307eb0984eb43e815dcacea3ac50c11d00a936ecf694c46991cd5a23bcb0ec0"},
-    {file = "immutables-0.16-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7a58825ff2254e2612c5a932174398a4ea8fbddd8a64a02c880cc32ee28b8820"},
-    {file = "immutables-0.16-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:798b095381eb42cf40db6876339e7bed84093e5868018a9e73d8e1f7ab4bb21e"},
-    {file = "immutables-0.16-cp37-cp37m-win32.whl", hash = "sha256:19bdede174847c2ef1292df0f23868ab3918b560febb09fcac6eec621bd4812b"},
-    {file = "immutables-0.16-cp37-cp37m-win_amd64.whl", hash = "sha256:9ccf4c0e3e2e3237012b516c74c49de8872ccdf9129739f7a0b9d7444a8c4862"},
-    {file = "immutables-0.16-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:d59beef203a3765db72b1d0943547425c8318ecf7d64c451fd1e130b653c2fbb"},
-    {file = "immutables-0.16-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0020aaa4010b136056c20a46ce53204e1407a9e4464246cb2cf95b90808d9161"},
-    {file = "immutables-0.16-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edd9f67671555af1eb99ad3c7550238487dd7ac0ac5205b40204ed61c9a922ac"},
-    {file = "immutables-0.16-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:298a301f85f307b4c056a0825eb30f060e64d73605e783289f3df37dd762bab8"},
-    {file = "immutables-0.16-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:b779617f5b94486bfd0f22162cd72eb5f2beb0214a14b75fdafb7b2c908ed0cb"},
-    {file = "immutables-0.16-cp38-cp38-win32.whl", hash = "sha256:511c93d8b1bbbf103ff3f1f120c5a68a9866ce03dea6ac406537f93ca9b19139"},
-    {file = "immutables-0.16-cp38-cp38-win_amd64.whl", hash = "sha256:b651b61c1af6cda2ee201450f2ffe048a5959bc88e43e6c312f4c93e69c9e929"},
-    {file = "immutables-0.16-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:aa7bf572ae1e006104c584be70dc634849cf0dc62f42f4ee194774f97e7fd17d"},
-    {file = "immutables-0.16-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:50793a44ba0d228ed8cad4d0925e00dfd62ea32f44ddee8854f8066447272d05"},
-    {file = "immutables-0.16-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:799621dcdcdcbb2516546a40123b87bf88de75fe7459f7bd8144f079ace6ec3e"},
-    {file = "immutables-0.16-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7bcf52aeb983bd803b7c6106eae1b2d9a0c7ab1241bc6b45e2174ba2b7283031"},
-    {file = "immutables-0.16-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:734c269e82e5f307fb6e17945953b67659d1731e65309787b8f7ba267d1468f2"},
-    {file = "immutables-0.16-cp39-cp39-win32.whl", hash = "sha256:a454d5d3fee4b7cc627345791eb2ca4b27fa3bbb062ccf362ecaaa51679a07ed"},
-    {file = "immutables-0.16-cp39-cp39-win_amd64.whl", hash = "sha256:2505d93395d3f8ae4223e21465994c3bc6952015a38dc4f03cb3e07a2b8d8325"},
-    {file = "immutables-0.16.tar.gz", hash = "sha256:d67e86859598eed0d926562da33325dac7767b7b1eff84e232c22abea19f4360"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-4.2.0-py3-none-any.whl", hash = "sha256:057e92c15bc8d9e8109738a48db0ccb31b4d9d5cfbee5a8670879a30be66304b"},
@@ -1478,20 +1335,11 @@ iniconfig = [
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 ipdb = [
-    {file = "ipdb-0.13.4.tar.gz", hash = "sha256:c85398b5fb82f82399fc38c44fe3532c0dde1754abee727d8f5cfcc74547b334"},
-    {file = "ipdb-0.13.5.tar.gz", hash = "sha256:521e55ade3d3f5e459df6474cfb1d1ef6d44ab4155f829695c7c3dc2a8ce5b2b"},
-    {file = "ipdb-0.13.6.tar.gz", hash = "sha256:1aa37e19e5b3b96c930fe7fe97193a54202c23a8d1b1c7763f76553f5b275731"},
-    {file = "ipdb-0.13.7.tar.gz", hash = "sha256:178c367a61c1039e44e17c56fcc4a6e7dc11b33561261382d419b6ddb4401810"},
-    {file = "ipdb-0.13.8.tar.gz", hash = "sha256:8d368fa048a93ad6c1985d7f1d78d68580c879e4053fc15714bdcf2a1b042d06"},
     {file = "ipdb-0.13.9.tar.gz", hash = "sha256:951bd9a64731c444fd907a5ce268543020086a697f6be08f7cc2c9a752a278c5"},
 ]
 ipython = [
-    {file = "ipython-7.16.2-py3-none-any.whl", hash = "sha256:2f644313be4fdc5c8c2a17467f2949c29423c9e283a159d1fc9bf450a1a300af"},
-    {file = "ipython-7.16.2.tar.gz", hash = "sha256:613085f8acb0f35f759e32bea35fba62c651a4a2e409a0da11414618f5eec0c4"},
-]
-ipython-genutils = [
-    {file = "ipython_genutils-0.2.0-py2.py3-none-any.whl", hash = "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8"},
-    {file = "ipython_genutils-0.2.0.tar.gz", hash = "sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"},
+    {file = "ipython-7.31.0-py3-none-any.whl", hash = "sha256:4c4234cdcc6b8f87c5b5c7af9899aa696ac5cfcf0e9f6d0688018bbee5c73bce"},
+    {file = "ipython-7.31.0.tar.gz", hash = "sha256:346c74db7312c41fa566d3be45d2e759a528dcc2994fe48aac1a03a70cd668a3"},
 ]
 isort = [
     {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
@@ -1510,8 +1358,8 @@ jmespath = [
     {file = "jmespath-0.10.0.tar.gz", hash = "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9"},
 ]
 jsonschema = [
-    {file = "jsonschema-4.0.0-py3-none-any.whl", hash = "sha256:c773028c649441ab980015b5b622f4cd5134cf563daaf0235ca4b73cc3734f20"},
-    {file = "jsonschema-4.0.0.tar.gz", hash = "sha256:bc51325b929171791c42ebc1c70b9713eb134d3bb8ebd5474c8b659b15be6d86"},
+    {file = "jsonschema-4.4.0-py3-none-any.whl", hash = "sha256:77281a1f71684953ee8b3d488371b162419767973789272434bbc3f29d9c8823"},
+    {file = "jsonschema-4.4.0.tar.gz", hash = "sha256:636694eb41b3535ed608fe04129f26542b59ed99808b4f688aa32dcf55317a83"},
 ]
 lazy-object-proxy = [
     {file = "lazy-object-proxy-1.7.1.tar.gz", hash = "sha256:d609c75b986def706743cdebe5e47553f4a5a1da9c5ff66d76013ef396b5a8a4"},
@@ -1635,6 +1483,10 @@ marshmallow-polyfield = [
     {file = "marshmallow-polyfield-5.10.tar.gz", hash = "sha256:75d0e31b725650e91428f975a66ed30f703cc6f9fcfe45b8436ee6d676921691"},
     {file = "marshmallow_polyfield-5.10-py3-none-any.whl", hash = "sha256:a0a91730c6d21bfac1563990c7ba1413928e7499af669619d4fb38d1fb25c4e9"},
 ]
+matplotlib-inline = [
+    {file = "matplotlib-inline-0.1.3.tar.gz", hash = "sha256:a04bfba22e0d1395479f866853ec1ee28eea1485c1d69a6faf00dc3e24ff34ee"},
+    {file = "matplotlib_inline-0.1.3-py3-none-any.whl", hash = "sha256:aed605ba3b72462d64d475a21a9296f400a19c4f74a31b59103d2a99ffd5aa5c"},
+]
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
@@ -1660,16 +1512,16 @@ pickleshare = [
     {file = "pickleshare-0.7.5.tar.gz", hash = "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca"},
 ]
 platformdirs = [
-    {file = "platformdirs-2.4.0-py3-none-any.whl", hash = "sha256:8868bbe3c3c80d42f20156f22e7131d2fb321f5bc86a2a345375c6481a67021d"},
-    {file = "platformdirs-2.4.0.tar.gz", hash = "sha256:367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2"},
+    {file = "platformdirs-2.4.1-py3-none-any.whl", hash = "sha256:1d7385c7db91728b83efd0ca99a5afb296cab9d0ed8313a45ed8ba17967ecfca"},
+    {file = "platformdirs-2.4.1.tar.gz", hash = "sha256:440633ddfebcc36264232365d7840a970e75e1018d15b4327d11f91909045fda"},
 ]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
 prompt-toolkit = [
-    {file = "prompt_toolkit-3.0.19-py3-none-any.whl", hash = "sha256:7089d8d2938043508aa9420ec18ce0922885304cddae87fb96eebca942299f88"},
-    {file = "prompt_toolkit-3.0.19.tar.gz", hash = "sha256:08360ee3a3148bdb5163621709ee322ec34fc4375099afa4bbf751e9b7b7fa4f"},
+    {file = "prompt_toolkit-3.0.24-py3-none-any.whl", hash = "sha256:e56f2ff799bacecd3e88165b1e2f5ebf9bcd59e80e06d395fa0cc4b8bd7bb506"},
+    {file = "prompt_toolkit-3.0.24.tar.gz", hash = "sha256:1bb05628c7d87b645974a1bad3f17612be0c29fa39af9f7688030163f680bad6"},
 ]
 ptyprocess = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
@@ -1692,8 +1544,8 @@ pygments = [
     {file = "Pygments-2.11.2.tar.gz", hash = "sha256:4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a"},
 ]
 pylint = [
-    {file = "pylint-2.12.0-py3-none-any.whl", hash = "sha256:ba00afcb1550bc217bbcb0eb76c10cb8335f7417a3323bdd980c29fb5b59f8d2"},
-    {file = "pylint-2.12.0.tar.gz", hash = "sha256:245c87e5da54c35b623c21b35debf87d93b18bf9e0229515cc172d0b83d627cd"},
+    {file = "pylint-2.12.2-py3-none-any.whl", hash = "sha256:daabda3f7ed9d1c60f52d563b1b854632fd90035bcf01443e234d3dc794e3b74"},
+    {file = "pylint-2.12.2.tar.gz", hash = "sha256:9d945a73640e1fec07ee34b42f5669b770c759acd536ec7b16d7e4b87a9c9ff9"},
 ]
 pyparsing = [
     {file = "pyparsing-3.0.6-py3-none-any.whl", hash = "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4"},
@@ -1735,8 +1587,8 @@ pytest-datadir = [
     {file = "pytest_datadir-1.3.1-py2.py3-none-any.whl", hash = "sha256:1847ed0efe0bc54cac40ab3fba6d651c2f03d18dd01f2a582979604d32e7621e"},
 ]
 pytest-socket = [
-    {file = "pytest-socket-0.4.1.tar.gz", hash = "sha256:b5abcfd14d9c03e7d4e2875bb5e190af28bf5b4162d0a83e3d7aee6d79f1c85d"},
-    {file = "pytest_socket-0.4.1-py3-none-any.whl", hash = "sha256:e3bc6cc9c2534289c6a5b9748ca733f6ae8c8d34f1fdab5115ca17a47860bf5e"},
+    {file = "pytest-socket-0.5.0.tar.gz", hash = "sha256:1a3b92c4889118c688610a8d2991b51e2893e1e519db9e4226261ce5e24f70e2"},
+    {file = "pytest_socket-0.5.0-py3-none-any.whl", hash = "sha256:fc2bfe4020255431dd9583dd657aa8b75c4f9e0c53c46566cf06ce40fe9ea0ce"},
 ]
 pytest-testmon = [
     {file = "pytest-testmon-1.2.2.tar.gz", hash = "sha256:e69d5aeac4e371986f94e8ad06e56d70633870d026f2306fca44051f02fcb688"},
@@ -1851,16 +1703,16 @@ toml = [
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 tomli = [
-    {file = "tomli-1.2.3-py3-none-any.whl", hash = "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"},
-    {file = "tomli-1.2.3.tar.gz", hash = "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f"},
+    {file = "tomli-2.0.0-py3-none-any.whl", hash = "sha256:b5bde28da1fed24b9bd1d4d2b8cba62300bfb4ec9a6187a957e8ddb9434c5224"},
+    {file = "tomli-2.0.0.tar.gz", hash = "sha256:c292c34f58502a1eb2bbb9f5bbc9a5ebc37bee10ffb8c2d6bbdfa8eb13cc14e1"},
 ]
 tomlkit = [
     {file = "tomlkit-0.8.0-py3-none-any.whl", hash = "sha256:b824e3466f1d475b2b5f1c392954c6cb7ea04d64354ff7300dc7c14257dc85db"},
     {file = "tomlkit-0.8.0.tar.gz", hash = "sha256:29e84a855712dfe0e88a48f6d05c21118dbafb283bb2eed614d46f80deb8e9a1"},
 ]
 traitlets = [
-    {file = "traitlets-4.3.3-py2.py3-none-any.whl", hash = "sha256:70b4c6a1d9019d7b4f6846832288f86998aa3b9207c6821f3578a6a6a467fe44"},
-    {file = "traitlets-4.3.3.tar.gz", hash = "sha256:d023ee369ddd2763310e4c3eae1ff649689440d4ae59d7485eb4cfbbe3e359f7"},
+    {file = "traitlets-5.1.1-py3-none-any.whl", hash = "sha256:2d313cc50a42cd6c277e7d7dc8d4d7fedd06a2c215f78766ae7b1a66277e0033"},
+    {file = "traitlets-5.1.1.tar.gz", hash = "sha256:059f456c5a7c1c82b98c2e8c799f39c9b8128f6d0d46941ee118daace9eb70c7"},
 ]
 typed-ast = [
     {file = "typed_ast-1.5.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5d8314c92414ce7481eee7ad42b353943679cf6f30237b5ecbf7d835519e1212"},
@@ -1978,6 +1830,6 @@ wrapt = [
     {file = "wrapt-1.13.3.tar.gz", hash = "sha256:1fea9cd438686e6682271d36f3481a9f3636195578bab9ca3382e2f5f01fc185"},
 ]
 zipp = [
-    {file = "zipp-3.6.0-py3-none-any.whl", hash = "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"},
-    {file = "zipp-3.6.0.tar.gz", hash = "sha256:71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832"},
+    {file = "zipp-3.7.0-py3-none-any.whl", hash = "sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375"},
+    {file = "zipp-3.7.0.tar.gz", hash = "sha256:9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -394,18 +394,18 @@ plugins = ["setuptools"]
 
 [[package]]
 name = "jedi"
-version = "0.17.2"
+version = "0.18.1"
 description = "An autocompletion tool for Python that can be used for text editors."
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
-parso = ">=0.7.0,<0.8.0"
+parso = ">=0.8.0,<0.9.0"
 
 [package.extras]
-qa = ["flake8 (==3.7.9)"]
-testing = ["Django (<3.1)", "colorama", "docopt", "pytest (>=3.9.0,<5.0.0)"]
+qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
+testing = ["Django (<3.1)", "colorama", "docopt", "pytest (<7.0.0)"]
 
 [[package]]
 name = "jinja2"
@@ -544,14 +544,15 @@ pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "parso"
-version = "0.7.1"
+version = "0.8.3"
 description = "A Python Parser"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.6"
 
 [package.extras]
-testing = ["docopt", "pytest (>=3.0.7)"]
+qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
+testing = ["docopt", "pytest (<6.0.0)"]
 
 [[package]]
 name = "pexpect"
@@ -1162,7 +1163,7 @@ test = ["pytest", "pytest-cov", "testfixtures", "responses", "freezegun", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "445392a8189a3924efe2b370fcb22010d02dfb9808a4a0875a33a9e9aae1faba"
+content-hash = "d4a35b8699c44051c55105cc1c18731240a3c29505f656ace27edcd599f9c8a9"
 
 [metadata.files]
 alabaster = [
@@ -1346,8 +1347,8 @@ isort = [
     {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
 ]
 jedi = [
-    {file = "jedi-0.17.2-py2.py3-none-any.whl", hash = "sha256:98cc583fa0f2f8304968199b01b6b4b94f469a1f4a74c1560506ca2a211378b5"},
-    {file = "jedi-0.17.2.tar.gz", hash = "sha256:86ed7d9b750603e4ba582ea8edc678657fb4007894a12bcf6f4bb97892f31d20"},
+    {file = "jedi-0.18.1-py2.py3-none-any.whl", hash = "sha256:637c9635fcf47945ceb91cd7f320234a7be540ded6f3e99a50cb6febdfd1ba8d"},
+    {file = "jedi-0.18.1.tar.gz", hash = "sha256:74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab"},
 ]
 jinja2 = [
     {file = "Jinja2-3.0.3-py3-none-any.whl", hash = "sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8"},
@@ -1500,8 +1501,8 @@ packaging = [
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
 parso = [
-    {file = "parso-0.7.1-py2.py3-none-any.whl", hash = "sha256:97218d9159b2520ff45eb78028ba8b50d2bc61dcc062a9682666f2dc4bd331ea"},
-    {file = "parso-0.7.1.tar.gz", hash = "sha256:caba44724b994a8a5e086460bb212abc5a8bc46951bf4a9a1210745953622eb9"},
+    {file = "parso-0.8.3-py2.py3-none-any.whl", hash = "sha256:c001d4636cd3aecdaf33cbb40aebb59b094be2a74c556778ef5576c175e19e75"},
+    {file = "parso-0.8.3.tar.gz", hash = "sha256:8c07be290bb59f03588915921e29e8a50002acaf2cdc5fa0e0114f91709fafa0"},
 ]
 pexpect = [
     {file = "pexpect-4.8.0-py2.py3-none-any.whl", hash = "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -737,11 +737,11 @@ pytest = ">=2.7.0"
 
 [[package]]
 name = "pytest-socket"
-version = "0.5.0"
+version = "0.4.1"
 description = "Pytest Plugin to disable socket calls during tests"
 category = "main"
 optional = true
-python-versions = ">=3.7,<4.0"
+python-versions = ">=3.6,<4.0"
 
 [package.dependencies]
 pytest = ">=3.6.3"
@@ -1163,7 +1163,7 @@ test = ["pytest", "pytest-cov", "testfixtures", "responses", "freezegun", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "d4a35b8699c44051c55105cc1c18731240a3c29505f656ace27edcd599f9c8a9"
+content-hash = "636e3841ba493263aeb91608ce609ac356e661db262f6cccd2387602593453b4"
 
 [metadata.files]
 alabaster = [
@@ -1588,8 +1588,8 @@ pytest-datadir = [
     {file = "pytest_datadir-1.3.1-py2.py3-none-any.whl", hash = "sha256:1847ed0efe0bc54cac40ab3fba6d651c2f03d18dd01f2a582979604d32e7621e"},
 ]
 pytest-socket = [
-    {file = "pytest-socket-0.5.0.tar.gz", hash = "sha256:1a3b92c4889118c688610a8d2991b51e2893e1e519db9e4226261ce5e24f70e2"},
-    {file = "pytest_socket-0.5.0-py3-none-any.whl", hash = "sha256:fc2bfe4020255431dd9583dd657aa8b75c4f9e0c53c46566cf06ce40fe9ea0ce"},
+    {file = "pytest-socket-0.4.1.tar.gz", hash = "sha256:b5abcfd14d9c03e7d4e2875bb5e190af28bf5b4162d0a83e3d7aee6d79f1c85d"},
+    {file = "pytest_socket-0.4.1-py3-none-any.whl", hash = "sha256:e3bc6cc9c2534289c6a5b9748ca733f6ae8c8d34f1fdab5115ca17a47860bf5e"},
 ]
 pytest-testmon = [
     {file = "pytest-testmon-1.2.2.tar.gz", hash = "sha256:e69d5aeac4e371986f94e8ad06e56d70633870d026f2306fca44051f02fcb688"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,5 +106,6 @@ ipdb = "*"
 icecream = "*"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+# https://github.com/python-poetry/poetry/issues/1993
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Use the default style and override some things (like the Python version)
 style = [
     "nitpick-style",
-    "py://nitpick/resources/python/36.toml",
+    "py://nitpick/resources/python/37.toml",
     "py://nitpick/resources/python/stable.toml"
 ]
 
@@ -47,7 +47,7 @@ toml = "nitpick.plugins.toml"
 yaml = "nitpick.plugins.yaml"
 
 [tool.poetry.dependencies]
-python = "^3.6.1"
+python = "^3.7"
 flake8 = ">=3.0.0"
 attrs = "*"
 tomlkit = ">=0.8.0" # SingleKey() class introduced in this version
@@ -68,12 +68,11 @@ marshmallow-polyfield = "^5.10"
 identify = "*"
 "more-itertools" = "*"
 pluggy = "*"
-dataclasses = { version = "*", python = ">=3.6, <3.7" }  # TODO: use attrs instead
 autorepr = "*"
 loguru = "*"
 ConfigUpdater = "*"
 cachy = "*"
-importlib-resources = { version = "*", python = ">=3.6, <3.9" }
+importlib-resources = { version = "*", python = ">=3.7, <3.9" }
 
 # TODO: Move to dependency groups once the feature is on a stable version of Poetry
 #  https://python-poetry.org/docs/master/managing-dependencies/#dependency-groups

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,9 @@ responses = { version = "*", optional = true }
 freezegun = { version = "*", optional = true }
 pytest-testmon = { version = "*", optional = true }
 pytest-watch = { version = "*", optional = true }
-pytest-socket = { version = "*", optional = true }
+# TODO: 0.5.0 fails with AttributeError: 'DoctestItem' object has no attribute 'fixturenames'
+#  See https://github.com/miketheman/pytest-socket/issues/105
+pytest-socket = { version = "<0.5.0", optional = true }
 pytest-datadir = { version = "*", optional = true }
 # Group: doc
 sphinx = { version = "*", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,10 +100,6 @@ doc = ["sphinx", "sphinx_rtd_theme", "sphobjinv"]
 
 [tool.poetry.dev-dependencies]
 ipython = "*"
-# TODO: remove jedi when iPython is upgraded to 7.20.0.
-#  poetry show ipython --tree
-#  https://github.com/ipython/ipython/issues/12745#issuecomment-771180253
-jedi = "<=0.17.2"
 ipdb = "*"
 icecream = "*"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ per-file-ignores =
     compat.py:F401
 
 # https://github.com/asottile/flake8-typing-imports#configuration
-min_python_version = 3.6.0
+min_python_version = 3.7.0
 
 [isort]
 # https://pycqa.github.io/isort/docs/configuration/options/

--- a/src/nitpick/resources/python/36.toml
+++ b/src/nitpick/resources/python/36.toml
@@ -1,2 +1,0 @@
-["pyproject.toml".tool.poetry.dependencies]
-python = "^3.6.1"

--- a/src/nitpick/resources/python/github-workflow.toml
+++ b/src/nitpick/resources/python/github-workflow.toml
@@ -7,7 +7,7 @@ fail-fast = false
 
 [".github/workflows/python.yaml".jobs.build.strategy.matrix]
 os = ["ubuntu-latest", "windows-latest", "macos-latest"]
-python-version = ["3.6", "3.7", "3.8", "3.9", "3.10"]
+python-version = ["3.7", "3.8", "3.9", "3.10"]
 
 [".github/workflows/python.yaml".jobs.build]
 name = "${{ matrix.python-version }} ${{ matrix.os }}"

--- a/src/nitpick/resources/python/hooks.toml
+++ b/src/nitpick/resources/python/hooks.toml
@@ -27,3 +27,4 @@ repo = "https://github.com/asottile/pyupgrade"
 
 [[".pre-commit-config.yaml".repos.hooks]]
 id = "pyupgrade"
+args = ["--py37-plus"]

--- a/src/nitpick/resources/python/stable.toml
+++ b/src/nitpick/resources/python/stable.toml
@@ -1,5 +1,4 @@
 [".readthedocs.yml".python]
 # ReadTheDocs still didn't upgrade to Python 3.9:
-# Problem in your project's configuration. Invalid "python.version":
-# expected one of (2, 2.7, 3, 3.5, 3.6, 3.7, 3.8, pypy3.5), got 3.9
+# Problem in your project's configuration. Invalid "python.version"
 version = "3.8"

--- a/src/nitpick/style/config.py
+++ b/src/nitpick/style/config.py
@@ -14,7 +14,7 @@ from nitpick.schemas import BaseStyleSchema, NitpickSectionSchema
 from nitpick.typedefs import JsonDict
 
 
-@dataclass(repr=True)
+@dataclass(repr=True)  # TODO: use attrs instead
 class ConfigValidator:
     """Validate a nitpick configuration."""
 

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -474,6 +474,8 @@ def test_fetch_private_github_urls(tmp_path):
         responses.GET,
         full_raw_url,
         dedent(body),
+        # TODO: fix DeprecationWarning: Argument 'match_querystring' is deprecated.
+        #  Use 'responses.matchers.query_param_matcher' or 'responses.matchers.query_string_matcher'
         match_querystring=False,
         status=200,
     )

--- a/tests/test_yaml/existing-actual.yaml
+++ b/tests/test_yaml/existing-actual.yaml
@@ -1,6 +1,6 @@
 # Root comment
 python:
-  version: 3.6  # Python 3.6 EOL this month!
+  version: 3.7  # This comment should be kept
   install:
     - method: pip
       path: .

--- a/tests/test_yaml/existing-expected.yaml
+++ b/tests/test_yaml/existing-expected.yaml
@@ -1,6 +1,6 @@
 # Root comment
 python:
-  version: '3.9' # Python 3.6 EOL this month!
+  version: '3.9' # This comment should be kept
   install:
     - method: pip
       path: .

--- a/tests/test_yaml/new-desired.toml
+++ b/tests/test_yaml/new-desired.toml
@@ -12,7 +12,7 @@ with = {"python-version" = "${{ matrix.python-version }}"}
 
 [".github/workflows/python.yaml".jobs.build.strategy.matrix]
 os = ["ubuntu-latest", "macos-latest", "windows-latest"]
-"python-version" = ["3.6", "3.7", "3.8", "3.9", "3.10"]
+"python-version" = ["3.7", "3.8", "3.9", "3.10"]
 
 [".github/workflows/python.yaml".jobs.build]
 "runs-on" = "${{ matrix.os }}"

--- a/tests/test_yaml/new-expected.yaml
+++ b/tests/test_yaml/new-expected.yaml
@@ -14,7 +14,6 @@ jobs:
           - macos-latest
           - windows-latest
         python-version:
-          - '3.6'
           - '3.7'
           - '3.8'
           - '3.9'

--- a/tests/test_yaml_pre_commit/real.yaml
+++ b/tests/test_yaml_pre_commit/real.yaml
@@ -39,6 +39,7 @@ repos:
     rev: v2.31.0
     hooks:
       - id: pyupgrade
+        args: [--py37-plus]
   - repo: https://github.com/myint/autoflake
     rev: v1.4
     hooks:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 # https://tox.readthedocs.io/en/latest/config.html
 isolated_build = True
-envlist = clean,lint,py310,py39,py38,py37,py36,docs,report
+envlist = clean,lint,py310,py39,py38,py37,docs,report
 
 # https://github.com/ymyzk/tox-gh-actions breaks with "InterpreterNotFound" when there is a "requires" key
 #   clean: commands succeeded
@@ -10,7 +10,6 @@ envlist = clean,lint,py310,py39,py38,py37,py36,docs,report
 #    py39: commands succeeded
 #    py38: commands succeeded
 #  ERROR:  py37: InterpreterNotFound: python3.7
-#  ERROR:  py36: InterpreterNotFound: python3.6
 #    docs: commands succeeded
 #    report: commands succeeded
 requires =
@@ -22,8 +21,8 @@ requires =
 description = Run tests with pytest and coverage
 extras = test
 depends =
-    {py310,py39,py38,py37,py36}: clean
-    report: py310,py39,py38,py37,py36
+    {py310,py39,py38,py37}: clean
+    report: py310,py39,py38,py37
 setenv =
     PY_IGNORE_IMPORTMISMATCH = 1
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -30,8 +30,7 @@ commands =
     # https://pytest-cov.readthedocs.io/en/latest/config.html#caveats
     # https://docs.pytest.org/en/stable/skipping.html
     # show extra test summary info for all tests except passed (failed/error/skipped/xfail/xpassed):
-    python -m pytest --cov-config=tox.ini --cov --cov-append --cov-report=term-missing --fixtures-per-test --doctest-modules -s -ra {posargs:}
-    # See https://github.com/miketheman/pytest-socket/issues/105
+    python -m pytest --cov-config=tox.ini --cov --cov-append --cov-report=term-missing --doctest-modules -s -ra {posargs:}
 
 [testenv:clean]
 description = Erase data for the coverage report before running tests

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,8 @@ commands =
     # https://pytest-cov.readthedocs.io/en/latest/config.html#caveats
     # https://docs.pytest.org/en/stable/skipping.html
     # show extra test summary info for all tests except passed (failed/error/skipped/xfail/xpassed):
-    python -m pytest --cov-config=tox.ini --cov --cov-append --cov-report=term-missing --doctest-modules -s -ra {posargs:}
+    # FIXME: --doctest-modules is failing on CI: AttributeError: 'DoctestItem' object has no attribute 'fixturenames'
+    python -m pytest --cov-config=tox.ini --cov --cov-append --cov-report=term-missing -s -ra {posargs:}
 
 [testenv:clean]
 description = Erase data for the coverage report before running tests

--- a/tox.ini
+++ b/tox.ini
@@ -30,8 +30,8 @@ commands =
     # https://pytest-cov.readthedocs.io/en/latest/config.html#caveats
     # https://docs.pytest.org/en/stable/skipping.html
     # show extra test summary info for all tests except passed (failed/error/skipped/xfail/xpassed):
-    # FIXME: --doctest-modules is failing on CI: AttributeError: 'DoctestItem' object has no attribute 'fixturenames'
-    python -m pytest --cov-config=tox.ini --cov --cov-append --cov-report=term-missing -s -ra {posargs:}
+    python -m pytest --cov-config=tox.ini --cov --cov-append --cov-report=term-missing --fixtures-per-test --doctest-modules -s -ra {posargs:}
+    # See https://github.com/miketheman/pytest-socket/issues/105
 
 [testenv:clean]
 description = Erase data for the coverage report before running tests


### PR DESCRIPTION
## Proposed changes

- [x] Remove Python 3.6, it has reached EOL
  - [PEP 494 -- Python 3.6 Release Schedule | Python.org](https://www.python.org/dev/peps/pep-0494/)
  - [Python Release Python 3.6.0 | Python.org](https://www.python.org/downloads/release/python-360/)
  - [Is Python 3.6 EOL? - Users - Discussions on Python.org](https://discuss.python.org/t/is-python-3-6-eol/12765)
- [x] Use pyupgrade with `--py37-plus` to change the code
- [x] See https://github.com/andreoliwa/nitpick/issues/250 as a reference

## Checklist

- [x] Read the [contribution guidelines](https://nitpick.rtfd.io/en/latest/contributing.html)
- [x] Run `make` locally before pushing commits
- [x] Add tests for the relevant parts:
  - [x] API
  - [x] CLI
  - [x] `flake8` plugin (normal mode)
  - [x] `flake8` plugin (offline mode)
- [x] Write documentation when there's a new API or functionality
