### PR TITLE
ci: try to run shellcheck on pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,8 +9,7 @@ default_language_version:
 
 # https://pre-commit.ci/#configuration
 ci:
-  # TODO: ci: use shellcheck-py to run shellcheck on pre-commit.ci
-  skip: [local-nitpick, autofix-docs, pylint, shellcheck]
+  skip: [local-nitpick, autofix-docs, pylint]
 
 repos:
   - repo: local
@@ -144,6 +143,10 @@ repos:
       - id: bandit
         args: [--ini, setup.cfg]
         exclude: tests/
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.8.0.3
+    hooks:
+      - id: shellcheck
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: 2.1.5
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -147,10 +147,6 @@ repos:
     rev: v0.8.0.3
     hooks:
       - id: shellcheck
-  - repo: https://github.com/jumanjihouse/pre-commit-hooks
-    rev: 2.1.5
-    hooks:
-      - id: shellcheck
   - repo: https://github.com/openstack/bashate
     rev: 2.1.0
     hooks:

--- a/src/nitpick/resources/shell/shellcheck.toml
+++ b/src/nitpick/resources/shell/shellcheck.toml
@@ -7,8 +7,10 @@ url = "https://github.com/koalaman/shellcheck"
 enabled = true
 
 [[".pre-commit-config.yaml".repos]]
-repo = "https://github.com/jumanjihouse/pre-commit-hooks"
+# This repo installs the "shellcheck" executable, and this is needed in order to run it on https://pre-commit.ci.
+# The previous hook I used (https://github.com/jumanjihouse/pre-commit-hooks) didn't do that, and fails with the error
+# "This check needs shellcheck from https://github.com/koalaman/shellcheck"
+repo = "https://github.com/shellcheck-py/shellcheck-py"
 
 [[".pre-commit-config.yaml".repos.hooks]]
-# https://github.com/jumanjihouse/pre-commit-hooks#shellcheck
 id = "shellcheck"

--- a/tests/test_builtin/shell/shellcheck/.pre-commit-config.yaml
+++ b/tests/test_builtin/shell/shellcheck/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
 repos:
-  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+  - repo: https://github.com/shellcheck-py/shellcheck-py
     hooks:
       - id: shellcheck


### PR DESCRIPTION
## Proposed changes

1. [shellcheck](https://github.com/koalaman/shellcheck) has to be installed on pre-commit.ci; trying [shellcheck-py](https://github.com/shellcheck-py/shellcheck-py) to do this job

## Checklist

- [x] Read the [contribution guidelines](https://nitpick.rtfd.io/en/latest/contributing.html)
- [x] Run `make` locally before pushing commits
- [x] Add tests for the relevant parts:
  - [x] API
  - [x] CLI
  - [x] `flake8` plugin (normal mode)
  - [x] `flake8` plugin (offline mode)
- [x] Write documentation when there's a new API or functionality
