### PR TITLE
feat: add --version cli switch

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -44,6 +44,7 @@ Main options
       -p, --project DIRECTORY  Path to project root
       --offline                Offline mode: no style will be downloaded (no HTTP
                                requests at all)
+      --version                Show the version and exit.
       --help                   Show this message and exit.
 
     Commands:

--- a/src/nitpick/cli.py
+++ b/src/nitpick/cli.py
@@ -49,6 +49,7 @@ FILES_ARGUMENT = click.argument("files", nargs=-1)
     default=False,
     help=OptionEnum.OFFLINE.value,
 )
+@click.version_option()
 def nitpick_cli(project: Path = None, offline=False):  # pylint: disable=unused-argument
     """Enforce the same settings across multiple language-independent projects."""
 


### PR DESCRIPTION
Fix these issue(s): #463

## Proposed changes

Uses the `@cli.version_option()` utility decorator to add a `--version` cli
switch:

```sh
$ nitpick --version
nitpick, version 0.31.0
```

I didn't add a test for this as it is a single line change; the click project
has this covered nicely already.

## Checklist

- [x] Read the [contribution guidelines](https://nitpick.rtfd.io/en/latest/contributing.html)
- [x] Run `make` locally before pushing commits
- [x] Add tests for the relevant parts:
  - [ ] API
  - [ ] CLI
  - [ ] `flake8` plugin (normal mode)
  - [ ] `flake8` plugin (offline mode)
- [x] Write documentation when there's a new API or functionality
