### PR TITLE
feat: Add MegaLinter plugin

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -34,3 +34,7 @@ replace = version = "{new_version}"
 [bumpversion:file:src/nitpick/__init__.py]
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
+
+[bumpversion:file:mega-linter-plugin-nitpick/nitpick.megalinter-descriptor.yml]
+search = {current_version}
+replace = {new_version}

--- a/README.rst
+++ b/README.rst
@@ -393,6 +393,19 @@ If you want to run Nitpick as a flake8 plugin instead::
           - id: flake8
             additional_dependencies: [nitpick]
 
+Run as a MegaLinter plugin
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you use `MegaLinter <https://megalinter.github.io/>`_ you can run Nitpick as a plugin. Add the following two entries to your ``.mega-linter.yml`` configuration file:
+
+.. code-block:: yaml
+
+    PLUGINS:
+      - https://raw.githubusercontent.com/andreoliwa/nitpick/v0.32.0/mega-linter-plugin-nitpick/nitpick.megalinter-descriptor.yml
+    ENABLE_LINTERS:
+      - NITPICK
+
+
 More information
 ----------------
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -92,6 +92,18 @@ To start checking all your code against the default rules:
 
     pre-commit run --all-files
 
+Run as a MegaLinter plugin
+---------------------------
+
+If you use `MegaLinter <https://megalinter.github.io/>`_ you can run Nitpick as a plugin. Add the following two entries to your ``.mega-linter.yml`` configuration file:
+
+.. code-block:: yaml
+
+    PLUGINS:
+      - https://raw.githubusercontent.com/andreoliwa/nitpick/v0.32.0/mega-linter-plugin-nitpick/nitpick.megalinter-descriptor.yml
+    ENABLE_LINTERS:
+      - NITPICK
+
 Modify files directly
 ---------------------
 

--- a/mega-linter-plugin-nitpick/nitpick.megalinter-descriptor.yml
+++ b/mega-linter-plugin-nitpick/nitpick.megalinter-descriptor.yml
@@ -1,0 +1,30 @@
+descriptor_id: NITPICK
+descriptor_type: tooling_format
+descriptor_flavors:
+  - all_flavors
+file_extensions:
+  - "*"
+active_only_if_file_found:
+  - ".nitpick.toml"
+  - "pyproject.toml"
+linters:
+  - linter_name: nitpick
+    linter_url: https://nitpick.readthedocs.io/
+    name: NITPICK
+    install:
+      dockerfile:
+        - RUN pip install nitpick==0.32.0
+    examples:
+      - "nitpick check"
+      - "nitpick fix"
+    cli_help_arg_name: --help
+    cli_lint_mode: project
+    cli_lint_errors_count: regex_sum
+    cli_lint_errors_regex: "Violations:.*([0-9]+)"
+    cli_lint_extra_args:
+      - "check"
+    cli_lint_fix_arg_name: "fix"
+    cli_lint_fix_remove_args:
+      - "check"
+    cli_lint_extra_args_after:
+      - "--verbose"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
             "docs/conf.py",
             "docs/configuration.rst",
             "docs/quickstart.rst",
+            "mega-linter-plugin-nitpick/nitpick.megalinter-descriptor.yml",
             "nitpick-style.toml",
             "package.json",
             "pyproject.toml",


### PR DESCRIPTION
This makes it possible to run nitpick as a [MegaLinter](https://megalinter.github.io/) step.

This installs a specific version of nitpick, so you can, in future, link to a
particular release and know it'll remain stable.

## Checklist

- [x] Read the [contribution guidelines](https://nitpick.rtfd.io/en/latest/contributing.html)
- [x] Run `make` locally before pushing commits
- [ ] Add tests for the relevant parts:
  - [ ] API
  - [ ] CLI
  - [ ] `flake8` plugin (normal mode)
  - [ ] `flake8` plugin (offline mode)
- [x] Write documentation when there's a new API or functionality
