### PR TITLE
fix: actually show chosen styles in log output

### DIFF
--- a/src/nitpick/project.py
+++ b/src/nitpick/project.py
@@ -10,7 +10,6 @@ import tomlkit
 from autorepr import autorepr
 from loguru import logger
 from marshmallow_polyfield import PolyField
-from more_itertools import peekable
 from more_itertools.more import always_iterable
 from pluggy import PluginManager
 from tomlkit.items import KeyType, SingleKey
@@ -182,7 +181,7 @@ class Project:
 
         style = StyleManager(self, offline, config.cache)
         base = config.file.expanduser().resolve().as_uri() if config.file else None
-        style_errors = list(style.find_initial_styles(peekable(always_iterable(config.styles)), base))
+        style_errors = list(style.find_initial_styles(list(always_iterable(config.styles)), base))
         if style_errors:
             raise QuitComplainingError(style_errors)
 

--- a/src/nitpick/style/core.py
+++ b/src/nitpick/style/core.py
@@ -93,10 +93,12 @@ class StyleManager:  # pylint: disable=too-many-instance-attributes
 
         """
         project_root = self.project.root
+        base_url = furl(base or project_root.resolve().as_uri())
 
         if configured_styles:
             chosen_styles = configured_styles
-            logger.info(f"Using styles configured in {PYPROJECT_TOML}: {chosen_styles}")
+            config_file = base_url.path.segments[-1] if base else PYPROJECT_TOML
+            logger.info(f"Using styles configured in {config_file}: {', '.join(chosen_styles)}")
         else:
             paths = glob_files(project_root, [NITPICK_STYLE_TOML])
             if paths:
@@ -107,7 +109,6 @@ class StyleManager:  # pylint: disable=too-many-instance-attributes
                 log_message = "Using default remote Nitpick style"
             logger.info(f"{log_message}: {chosen_styles[0]}")
 
-        base_url = furl(base or project_root.resolve().as_uri())
         yield from self.include_multiple_styles(
             self._style_fetcher_manager.normalize_url(ref, base_url) for ref in chosen_styles
         )


### PR DESCRIPTION
There were two issues with the log output:

- It always claimed the configured styles came from pyproject.toml even when
  .nitpick.toml is actually used.
- The chosen styles were shown as `<more_itertools.more.peekable object at 0x[hex address]>`

## Checklist

- [x] Read the [contribution guidelines](https://nitpick.rtfd.io/en/latest/contributing.html)
- [x] Run `make` locally before pushing commits
- [x] Add tests for the relevant parts:
  - [x] API
  - [ ] CLI
  - [ ] `flake8` plugin (normal mode)
  - [ ] `flake8` plugin (offline mode)
- [ ] Write documentation when there's a new API or functionality
