### PR TITLE
fix: further improve file path handling

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -48,7 +48,6 @@ jobs:
       # It fails with "Error: Lcov file not found."
       # Solution here: https://github.com/coverallsapp/github-action/issues/30#issuecomment-612523058
       - name: Coveralls
-        if: matrix.os == 'ubuntu-latest'
         uses: AndreMiras/coveralls-python-action@develop
         with:
           parallel: true

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -48,6 +48,7 @@ jobs:
       # It fails with "Error: Lcov file not found."
       # Solution here: https://github.com/coverallsapp/github-action/issues/30#issuecomment-612523058
       - name: Coveralls
+        if: matrix.os == 'ubuntu-latest'
         uses: AndreMiras/coveralls-python-action@develop
         with:
           parallel: true

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -48,6 +48,9 @@ jobs:
       # It fails with "Error: Lcov file not found."
       # Solution here: https://github.com/coverallsapp/github-action/issues/30#issuecomment-612523058
       - name: Coveralls
+        # TODO: ci: run code coverage on all platforms to fix missing coverage
+        #   Example: https://github.com/andreoliwa/nitpick/pull/479#issuecomment-1082074275
+        # This condition is needed otherwise it fails with "Error: Container action is only supported on Linux"
         if: matrix.os == 'ubuntu-latest'
         uses: AndreMiras/coveralls-python-action@develop
         with:

--- a/src/nitpick/style/core.py
+++ b/src/nitpick/style/core.py
@@ -27,7 +27,7 @@ from nitpick.constants import (
     PYPROJECT_TOML,
 )
 from nitpick.exceptions import QuitComplainingError, pretty_exception
-from nitpick.generic import furl_path_to_python_path
+from nitpick.generic import url_to_python_path
 from nitpick.plugins.base import NitpickPlugin
 from nitpick.plugins.info import FileInfo
 from nitpick.project import Project, glob_files
@@ -131,7 +131,7 @@ class StyleManager:  # pylint: disable=too-many-instance-attributes
         # and the URL otherwise.
         display_name = style_url.url
         if style_url.scheme == "file":
-            path = furl_path_to_python_path(style_url.path)
+            path = url_to_python_path(style_url)
             with suppress(ValueError):
                 path = path.relative_to(self.project.root)
             display_name = str(path)

--- a/src/nitpick/style/fetchers/file.py
+++ b/src/nitpick/style/fetchers/file.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
-import furl
+from furl import furl
 
-from nitpick.generic import furl_path_to_python_path
+from nitpick.generic import url_to_python_path
 from nitpick.style.fetchers import Scheme
 from nitpick.style.fetchers.base import StyleFetcher
 
@@ -32,10 +32,10 @@ class FileFetcher(StyleFetcher):  # pylint: disable=too-few-public-methods
         # cleanly against a file:// base. Relative paths should use POSIX conventions.
         return path.as_uri() if path.is_absolute() else path.as_posix()
 
-    def _normalize_path(self, path: furl.Path) -> furl.Path:
-        local_path = furl_path_to_python_path(super()._normalize_path(path))
-        return furl.furl(local_path.resolve().as_uri()).path
+    def _normalize_url_path(self, url: furl) -> furl:
+        local_path = url_to_python_path(super()._normalize_url_path(url))
+        return furl(local_path.resolve().as_uri())
 
-    def fetch(self, url: furl.furl) -> str:
+    def fetch(self, url: furl) -> str:
         """Fetch a style from a local file."""
-        return furl_path_to_python_path(url.path).read_text(encoding="UTF-8")
+        return url_to_python_path(url).read_text(encoding="UTF-8")

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -1,13 +1,15 @@
 """Generic functions tests."""
 import os
 import sys
-from pathlib import Path
+from pathlib import Path, PosixPath, WindowsPath
 from unittest import mock
 
+import pytest
+from furl import furl
 from testfixtures import compare
 
 from nitpick.constants import EDITOR_CONFIG, TOX_INI
-from nitpick.generic import relative_to_current_dir
+from nitpick.generic import _url_to_posix_path, _url_to_windows_path, relative_to_current_dir
 
 
 @mock.patch.object(Path, "cwd")
@@ -57,3 +59,35 @@ def test_relative_to_current_dir(home, cwd):
 
     for path, expected in examples.items():
         compare(actual=relative_to_current_dir(path), expected=expected, prefix=f"Path: {path}")
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows-only test")
+@pytest.mark.parametrize(
+    "test_path",
+    (
+        "C:\\",
+        r"C:\path\file.toml",
+        r"//server/share/path/file.toml",
+    ),
+)
+def test_url_to_windows_path(test_path):
+    """Verify that Path to URL to Path conversion preserses the path."""
+    path = WindowsPath(test_path)
+    url = furl(path.as_uri())
+    assert _url_to_windows_path(url) == path
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX-only test")
+@pytest.mark.parametrize(
+    "test_path",
+    (
+        "/",
+        "/path/to/file.toml",
+        "//double/slash/path.toml",
+    ),
+)
+def test_url_to_posix_path(test_path):
+    """Verify that Path to URL to Path conversion preserses the path."""
+    path = PosixPath(test_path)
+    url = furl(path.as_uri())
+    assert _url_to_posix_path(url) == path

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -71,7 +71,7 @@ def test_relative_to_current_dir(home, cwd):
     ),
 )
 def test_url_to_windows_path(test_path):
-    """Verify that Path to URL to Path conversion preserses the path."""
+    """Verify that Path to URL to Path conversion preserves the path."""
     path = WindowsPath(test_path)
     url = furl(path.as_uri())
     assert _url_to_windows_path(url) == path
@@ -87,7 +87,7 @@ def test_url_to_windows_path(test_path):
     ),
 )
 def test_url_to_posix_path(test_path):
-    """Verify that Path to URL to Path conversion preserses the path."""
+    """Verify that Path to URL to Path conversion preserves the path."""
     path = PosixPath(test_path)
     url = furl(path.as_uri())
     assert _url_to_posix_path(url) == path


### PR DESCRIPTION
- On Windows, reflection of file URLs to paths requires that we know about the URL hostname too as they could be UNC paths.
- Add some tests that verify that we are round-tripping from Path to URL and back again correctly.
- Simplify scheme testing for relative URLs, we only need to know about supported schemes.

## Checklist

- [x] Read the [contribution guidelines](https://nitpick.rtfd.io/en/latest/contributing.html)
- [x] Run `make` locally before pushing commits
- [x] Add tests for the relevant parts:
  - [x] API
  - [ ] CLI
  - [ ] `flake8` plugin (normal mode)
  - [ ] `flake8` plugin (offline mode)
- [ ] Write documentation when there's a new API or functionality
