### PR TITLE
Fix falsy values not being properly compared

### DIFF
--- a/src/nitpick/blender.py
+++ b/src/nitpick/blender.py
@@ -10,6 +10,7 @@ import abc
 import json
 import re
 import shlex
+from collections.abc import Iterable
 from functools import lru_cache, partial
 from pathlib import Path
 from typing import Any, Callable, TypeVar, cast
@@ -160,7 +161,7 @@ class ListDetail:  # pylint: disable=too-few-public-methods
 
 def set_key_if_not_empty(dict_: JsonDict, key: str, value: Any) -> None:
     """Update the dict if the value is valid."""
-    if not value:
+    if isinstance(value, Iterable) and not value:
         return
     dict_[key] = value
 

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -121,7 +121,6 @@ def test_objects_are_compared_by_hash_on_list_of_dicts_and_new_ones_are_added(tm
 
 def test_maximum_two_level_nesting_on_lists_using_jmes_expression_as_list_key_fails(tmp_path, datadir):
     """Test a maximum of two-level nesting on lists. Using a JMES expression as a list key will fail.
-
     Keys must have a maximum of 2 level for now: parent and nested keys.
     """
     filename = "an/arbitrary/file.yaml"
@@ -152,4 +151,28 @@ def test_maximum_two_level_nesting_on_lists_using_jmes_expression_as_list_key_fa
             """,
         ),
     ).assert_file_contents(filename, datadir / "jmes-list-key-expected.yaml")
+    project.api_check().assert_violations()
+
+
+def test_falsy_values_properly_reported(tmp_path, datadir):
+    filename = "foo/file.yaml"
+    project = ProjectMock(tmp_path).save_file(filename, datadir / "dict-falsy-values-actual.yaml")
+    project.style(datadir / "dict-falsy-values-desired.toml").api_check_then_fix(
+        Fuss(
+            True,
+            filename,
+            369,
+            " has different values. Use this:",
+            """
+            boolean_true_unmatch: true
+            boolean_false_unmatch: false
+            string_a_unmatch: string_a
+            string_b_unmatch: string_b
+            truthy_int_unmatch: 1
+            falsy_int_unmatch: 0
+            truthy_float_unmatch: 1.0
+            falsy_float_unmatch: 0.0
+            """,
+        ),
+    ).assert_file_contents(filename, datadir / "dict-falsy-values-expected.yaml")
     project.api_check().assert_violations()

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -121,6 +121,7 @@ def test_objects_are_compared_by_hash_on_list_of_dicts_and_new_ones_are_added(tm
 
 def test_maximum_two_level_nesting_on_lists_using_jmes_expression_as_list_key_fails(tmp_path, datadir):
     """Test a maximum of two-level nesting on lists. Using a JMES expression as a list key will fail.
+
     Keys must have a maximum of 2 level for now: parent and nested keys.
     """
     filename = "an/arbitrary/file.yaml"

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -155,6 +155,7 @@ def test_maximum_two_level_nesting_on_lists_using_jmes_expression_as_list_key_fa
 
 
 def test_falsy_values_properly_reported(tmp_path, datadir):
+    """Test that falsy and truthy values are included in the report."""
     filename = "foo/file.yaml"
     project = ProjectMock(tmp_path).save_file(filename, datadir / "dict-falsy-values-actual.yaml")
     project.style(datadir / "dict-falsy-values-desired.toml").api_check_then_fix(

--- a/tests/test_yaml/dict-falsy-values-actual.yaml
+++ b/tests/test_yaml/dict-falsy-values-actual.yaml
@@ -1,0 +1,16 @@
+boolean_true_match: true
+boolean_true_unmatch: false
+boolean_false_match: false
+boolean_false_unmatch: true
+string_a_match: 'string_a'
+string_a_unmatch: 'string_b'
+string_b_match: 'string_b'
+string_b_unmatch: 'string_a'
+truthy_int_match: 1
+truthy_int_unmatch: 0
+falsy_int_match: 0
+falsy_int_unmatch: 1
+truthy_float_match: 1.0
+truthy_float_unmatch: 0.0
+falsy_float_match: 0.0
+falsy_float_unmatch: 1.0

--- a/tests/test_yaml/dict-falsy-values-desired.toml
+++ b/tests/test_yaml/dict-falsy-values-desired.toml
@@ -1,0 +1,20 @@
+["foo/file.yaml"]
+boolean_true_match = true
+boolean_true_unmatch = true
+boolean_false_match = false
+boolean_false_unmatch = false
+
+string_a_match = "string_a"
+string_a_unmatch = "string_a"
+string_b_match = "string_b"
+string_b_unmatch = "string_b"
+
+truthy_int_match = 1
+truthy_int_unmatch = 1
+falsy_int_match = 0
+falsy_int_unmatch = 0
+
+truthy_float_match = 1.0
+truthy_float_unmatch = 1.0
+falsy_float_match = 0.0
+falsy_float_unmatch = 0.0

--- a/tests/test_yaml/dict-falsy-values-expected.yaml
+++ b/tests/test_yaml/dict-falsy-values-expected.yaml
@@ -1,0 +1,16 @@
+boolean_true_match: true
+boolean_true_unmatch: true
+boolean_false_match: false
+boolean_false_unmatch: false
+string_a_match: 'string_a'
+string_a_unmatch: 'string_a'
+string_b_match: 'string_b'
+string_b_unmatch: 'string_b'
+truthy_int_match: 1
+truthy_int_unmatch: 1
+falsy_int_match: 0
+falsy_int_unmatch: 0
+truthy_float_match: 1.0
+truthy_float_unmatch: 1.0
+falsy_float_match: 0.0
+falsy_float_unmatch: 0.0


### PR DESCRIPTION
Fixes #489

## Proposed changes

1. Check that the value is iterable to skip if falsy.

Note that I'm not totally aware of why the value is being truthly checked, maybe there is a good reason behind this, but without knowing why I intuitively would just remove the `if`.

## Checklist

- [x] Read the [contribution guidelines](https://nitpick.rtfd.io/en/latest/contributing.html)
- [x] Run `make` locally before pushing commits
- [x] Add tests for the relevant parts:
  - [x] API
  - [ ] CLI
  - [ ] `flake8` plugin (normal mode)
  - [ ] `flake8` plugin (offline mode)
- [ ] Write documentation when there's a new API or functionality
