### PR TITLE
fix(deps): pin requests-cache to >=1.0.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2114,4 +2114,4 @@ test = ["freezegun", "pytest", "pytest-cov", "pytest-datadir", "pytest-socket", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "b8b8b18f9dafe0e045e02152b9c7b6cfe2a578d1167e1a8d624a3c04bb2a9fed"
+content-hash = "7a282a4343b7e8e99b5572e20b085d81a94c135a3ab982326df4933e6497a1d6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ sphinx = { version = "*", optional = true }
 sphinx_rtd_theme = { version = "*", optional = true }
 sphobjinv = { version = "*", optional = true }
 sphinx-gitref = { version = "*", optional = true }
-requests-cache = ">=0.9.7" # This version uses requests_cache.policy.expiration
+requests-cache = ">=1.0.0" # This version uses requests_cache.policy.expiration
 
 [tool.poetry.extras]
 lint = ["pylint"]


### PR DESCRIPTION
## Proposed changes

1. requests-cache v0.9.8 breaks things. See https://github.com/andreoliwa/nitpick/pull/518#discussion_r1152120390

## Checklist

- [x] Read the [contribution guidelines](https://nitpick.rtfd.io/en/latest/contributing.html)
- [x] Run `make` locally before pushing commits
- [x] Add tests for the relevant parts:
  - [x] API
  - [x] CLI
  - [x] `flake8` plugin (normal mode)
  - [x] `flake8` plugin (offline mode)
- [x] Write documentation when there's a new API or functionality
