### PR TITLE
ci: fix GitHub Actions workflow to run on contributors' pull requests

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -5,10 +5,25 @@
 
 name: Python
 
-on: [push]
+on:
+  pull_request:
+  push:
 
 jobs:
+  # Adapted from https://github.com/marketplace/actions/skip-duplicate-actions
+  pre_job:
+    # continue-on-error: true # TODO: Uncomment once integration is finished
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+
   build:
+    needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true'
     name: "${{ matrix.python-version }} ${{ matrix.os }}"
     strategy:
       fail-fast: false

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -18,6 +18,9 @@ jobs:
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v5
+        with:
+          # https://github.com/marketplace/actions/skip-duplicate-actions#skip-concurrent-workflow-runs
+          concurrent_skipping: "same_content_newer"
 
   build:
     needs: pre_job

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -5,9 +5,7 @@
 
 name: Python
 
-on:
-  pull_request:
-  push:
+on: [push, pull_request]
 
 jobs:
   # Adapted from https://github.com/marketplace/actions/skip-duplicate-actions

--- a/src/nitpick/resources/presets/nitpick.toml
+++ b/src/nitpick/resources/presets/nitpick.toml
@@ -20,7 +20,7 @@ include = [
     "py://nitpick/resources/python/readthedocs",
     "py://nitpick/resources/python/sonar-python",
     "py://nitpick/resources/python/tox",
-#    "py://nitpick/resources/python/github-workflow", # TODO:
+    "py://nitpick/resources/python/github-workflow",
 
     "py://nitpick/resources/any/prettier",
     "py://nitpick/resources/any/codeclimate",

--- a/src/nitpick/resources/presets/nitpick.toml
+++ b/src/nitpick/resources/presets/nitpick.toml
@@ -20,7 +20,7 @@ include = [
     "py://nitpick/resources/python/readthedocs",
     "py://nitpick/resources/python/sonar-python",
     "py://nitpick/resources/python/tox",
-    "py://nitpick/resources/python/github-workflow",
+#    "py://nitpick/resources/python/github-workflow", # TODO:
 
     "py://nitpick/resources/any/prettier",
     "py://nitpick/resources/any/codeclimate",

--- a/src/nitpick/resources/python/github-workflow.toml
+++ b/src/nitpick/resources/python/github-workflow.toml
@@ -4,7 +4,7 @@ url = "https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-gi
 
 [".github/workflows/python.yaml"]
 name = "Python"
-on = ["push"]
+on = ["push", "pull_request"]
 
 [".github/workflows/python.yaml".jobs.build.strategy]
 fail-fast = false

--- a/tests/test_builtin/python/github-workflow/.github/workflows/python.yaml
+++ b/tests/test_builtin/python/github-workflow/.github/workflows/python.yaml
@@ -1,6 +1,7 @@
 name: Python
 on:
   - push
+  - pull_request
 jobs:
   build:
     strategy:


### PR DESCRIPTION
## Proposed changes

1. GitHub Actions workflow is not running on contributors' pull requests: https://github.com/andreoliwa/nitpick/pull/577
2. Run for both push and pull request but try to skip duplicates with https://github.com/marketplace/actions/skip-duplicate-actions

## Checklist

- [x] Read the [contribution guidelines](https://nitpick.rtfd.io/en/latest/contributing.html)
- [x] Run `make` locally before pushing commits
- ~~Add tests for the relevant parts:~~
  - ~~API~~
  - ~~CLI~~
  - ~~`flake8` plugin (normal mode)~~
  - ~~`flake8` plugin (offline mode)~~
- ~~Write documentation when there's a new API or functionality~~
