### PR TITLE
Stop passing filenames to `nitpick-check` @ pre-commit hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -27,3 +27,4 @@
   description: "Only check configuration files (TOML/INI/JSON/etc.) and print the violations, according to the Nitpick style"
   entry: nitpick check
   language: python
+  pass_filenames: false


### PR DESCRIPTION
The default is `pass_filenames: true`. This was causing the checks to be skipped even with `pre-commit run --all-files`. The hook was returning successful validation while there were multiple violations.