### PR TITLE
feat: Better file detection to allow more files with text plugin

### DIFF
--- a/src/nitpick/plugins/info.py
+++ b/src/nitpick/plugins/info.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from identify import identify
@@ -29,5 +30,11 @@ class FileInfo:
             clean_path = DOT + path_from_root
         else:
             clean_path = DOT + path_from_root[1:] if path_from_root.startswith("-") else path_from_root
-        tags = set(identify.tags_from_filename(clean_path))
+
+        # When we run identify on the actual file we get better tags
+        if Path(clean_path).exists():
+            tags = set(identify.tags_from_path(clean_path))
+        else:
+            tags = set(identify.tags_from_filename(clean_path))
+
         return cls(project, clean_path, tags)


### PR DESCRIPTION
Issues fixed by this pull request:

- Fix #

## Proposed changes

1. Run identify on the actual file instead of only the filename. For example a file called [`justfile`](https://just.systems/man/en/introduction.html) wil get the tag `text` if you do but not if you run it on the filename

## Checklist

- [x] Read the [contribution guidelines](https://nitpick.rtfd.io/en/latest/contributing.html)
- [x] Run `make` locally before pushing commits
- [x] Add tests for the relevant parts:
  - [ ] API
  - [ ] CLI
  - [ ] `flake8` plugin (normal mode)
  - [ ] `flake8` plugin (offline mode)
- [x] Write documentation when there's a new API or functionality
